### PR TITLE
Preparing for Linux automake packaging for distribution.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,11 +2,11 @@
 AUTOMAKE_OPTIONS =		subdir-objects
 ACLOCAL_AMFLAGS =		-I build-aux/m4
 
-ot_include_dir =		$(top_srcdir)/include
-ot_source_dir =			$(top_srcdir)/src
+opentxs_include_dir =		$(top_srcdir)/include
+opentxs_source_dir =		$(top_srcdir)/src
 
-common_includes =		-I$(ot_include_dir)				\
-				-I$(ot_include_dir)/otlib			\
+common_includes =		-I$(opentxs_include_dir)			\
+				-I$(opentxs_include_dir)/otlib			\
 				$(DEPS_CFLAGS)
 
 
@@ -45,7 +45,7 @@ endif
 
 ####	BigInt
 
-bigint_headers_dir =		$(ot_include_dir)/bigint
+bigint_headers_dir =		$(opentxs_include_dir)/bigint
 
 bigint_headers =		include/bigint/BigInteger.h			\
 				include/bigint/BigIntegerAlgorithms.h		\
@@ -55,7 +55,7 @@ bigint_headers =		include/bigint/BigInteger.h			\
 				include/bigint/BigUnsignedInABase.h		\
 				include/bigint/NumberlikeArray.h
 
-bigint_sources_dir =		$(ot_source_dir)/bigint
+bigint_sources_dir =		$(opentxs_source_dir)/bigint
 
 bigint_sources =		src/bigint/BigInteger.cc			\
 				src/bigint/BigIntegerAlgorithms.cc		\
@@ -63,27 +63,49 @@ bigint_sources =		src/bigint/BigInteger.cc			\
 				src/bigint/BigUnsigned.cc			\
 				src/bigint/BigUnsignedInABase.cc
 
+####	Simple Ini
+
+simpleini_headers_dir	=	$(opentxs_include_dir)/simpleini
+
+simpleini_headers	=	include/simpleini/ConvertUTF.h			\
+				include/simpleini/SimpleIni.h
+
+simpleini_sources_dir	= 	$(opentxs_source_dir)/simpleini
+
+simpleini_sources	=	src/simpleini/ConvertUTF.cpp			\
+				src/simpleini/snippets.cpp
+
 ####	Containers
 
-containers_headers_dir =	$(ot_include_dir)/containers
+containers_headers_dir	=	$(opentxs_include_dir)/containers
 
-containers_headers =		include/containers/containers.hpp		\
+containers_headers 	=	include/containers/containers.hpp		\
 				include/containers/containers_fixes.hpp		\
 				include/containers/copy_functors.hpp		\
 				include/containers/digraph.hpp			\
+				include/containers/digraph.tpp			\
 				include/containers/exceptions.hpp		\
 				include/containers/foursome.hpp			\
+				include/containers/foursome.tpp			\
 				include/containers/hash.hpp			\
+				include/containers/hash.tpp			\
 				include/containers/matrix.hpp			\
+				include/containers/matrix.tpp			\
 				include/containers/ntree.hpp			\
+				include/containers/ntree.tpp			\
 				include/containers/safe_iterator.hpp		\
+				include/containers/safe_iterator.tpp		\
 				include/containers/simple_ptr.hpp		\
+				include/containers/simple_ptr.tpp		\
 				include/containers/smart_ptr.hpp		\
-				include/containers/triple.hpp
+				include/containers/smart_ptr.tpp		\
+				include/containers/triple.hpp			\
+				include/containers/triple.tpp
+
 
 ####	IrrXML
 
-irrxml_headers_dir =		$(ot_include_dir)/irrxml
+irrxml_headers_dir =		$(opentxs_include_dir)/irrxml
 
 irrxml_headers =		include/irrxml/CXMLReaderImpl.h			\
 				include/irrxml/fast_atof.h			\
@@ -93,18 +115,18 @@ irrxml_headers =		include/irrxml/CXMLReaderImpl.h			\
 				include/irrxml/irrTypes.h			\
 				include/irrxml/irrXML.h
 
-irrxml_sources_dir = 		$(ot_source_dir)/irrxml
+irrxml_sources_dir = 		$(opentxs_source_dir)/irrxml
 
 irrxml_sources =		src/irrxml/irrXML.cpp
 
 
 ####	Lucre
 
-lucre_headers_dir =		$(ot_include_dir)/lucre
+lucre_headers_dir =		$(opentxs_include_dir)/lucre
 
 lucre_headers =			include/lucre/bank.h
 
-lucre_sources_dir = 		$(ot_source_dir)/lucre
+lucre_sources_dir = 		$(opentxs_source_dir)/lucre
 
 lucre_sources =			src/lucre/bankdemo.cpp				\
 				src/lucre/bankimp.cpp				\
@@ -116,14 +138,14 @@ lucre_sources =			src/lucre/bankdemo.cpp				\
 
 ####	OT
 
-ot_sources_dir = 		$(ot_source_dir)/ot
+ot_sources_dir = 		$(opentxs_source_dir)/ot
 
 ot_sources =			src/ot/main.cpp
 
 
 ####	OT API
 
-otapi_headers_dir =		$(ot_include_dir)/otapi
+otapi_headers_dir =		$(opentxs_include_dir)/otapi
 
 otapi_headers =			include/otapi/main.h				\
 				include/otapi/OpenTransactions.h		\
@@ -133,7 +155,7 @@ otapi_headers =			include/otapi/main.h				\
 				include/otapi/OTClient.h			\
 				include/otapi/OTServerConnection.h
 
-otapi_sources_dir = 		$(ot_source_dir)/otapi
+otapi_sources_dir = 		$(opentxs_source_dir)/otapi
 
 otapi_sources =			src/otapi/OpenTransactions.cpp			\
 				src/otapi/OTAPI.cpp				\
@@ -143,7 +165,7 @@ otapi_sources =			src/otapi/OpenTransactions.cpp			\
 
 ####	OT LIB
 
-otlib_headers_dir =		$(ot_include_dir)/otlib
+otlib_headers_dir =		$(opentxs_include_dir)/otlib
 
 otlib_headers =			include/otlib/anyoption.h			\
 				include/otlib/Bitcoin.pb.h			\
@@ -165,6 +187,7 @@ otlib_headers =			include/otlib/anyoption.h			\
 				include/otlib/OTCronItem.h			\
 				include/otlib/OTData.h				\
 				include/otlib/OTDataCheck.h			\
+				include/otlib/ot_default_paths.h		\
 				include/otlib/OTEnvelope.h			\
 				include/otlib/OTglobal.h			\
 				include/otlib/OTIdentifier.h			\
@@ -202,9 +225,10 @@ otlib_headers =			include/otlib/anyoption.h			\
 				include/otlib/OTWallet.h			\
 				include/otlib/stacktrace.h			\
 				include/otlib/Timer.h				\
-				include/otlib/tinythread.h
+				include/otlib/tinythread.h			\
+				include/otlib/WinsockWrapper.h
 
-otlib_sources_dir = 		$(ot_source_dir)/otlib
+otlib_sources_dir = 		$(opentxs_source_dir)/otlib
 
 otlib_sources     =		src/otlib/anyoption.cpp				\
 				src/otlib/Bitcoin.pb.cpp			\
@@ -263,33 +287,20 @@ otlib_sources     =		src/otlib/anyoption.cpp				\
 
 ####	OT Server
 
-otserver_headers_dir	=	$(ot_include_dir)/otserver
+otserver_headers_dir	=	$(opentxs_include_dir)/otserver
 
 otserver_headers	= 	include/otserver/main.h				\
 				include/otserver/OTClientConnection.h		\
 				include/otserver/OTServer.h
 
-otserver_sources_dir	=	$(ot_source_dir)/otserver
+otserver_sources_dir	=	$(opentxs_source_dir)/otserver
 
 otserver_sources	=	src/otserver/OTClientConnection.cpp		\
 				src/otserver/OTServer.cpp
 
-####	Simple Ini
-
-simpleini_headers_dir	=	$(ot_include_dir)/simpleini
-
-simpleini_headers	=	include/simpleini/ConvertUTF.h			\
-				include/simpleini/SimpleIni.h
-
-simpleini_sources_dir	= 	$(ot_source_dir)/simpleini
-
-simpleini_sources	=	src/simpleini/ConvertUTF.cpp			\
-				src/simpleini/snippets.cpp
-
-
 ####	OT Create Mint
 
-createmint_sources_dir	=	$(ot_source_dir)/createmint
+createmint_sources_dir	=	$(opentxs_source_dir)/createmint
 
 ####################################################################
 
@@ -325,7 +336,8 @@ liblucre_la_LDFLAGS	=	-static
 
 ####	LIB OT
 
-libot_la_SOURCES	=	$(otlib_sources) $(otlib_headers)
+libot_la_SOURCES	=	$(otlib_sources) $(otlib_headers)	\
+				$(containers_headers)
 
 libot_la_CPPFLAGS	=	$(AM_CPPFLAGS)
 
@@ -341,7 +353,8 @@ libot_la_LDFLAGS	=	--no-undefined
 
 ####	 LIB OT API
 
-libotapi_la_SOURCES	=	$(otapi_sources) $(otapi_headers)
+libotapi_la_SOURCES	=	$(otapi_sources) $(otapi_headers)	\
+				$(simpleini_headers)
 
 libotapi_la_CPPFLAGS	=	-I$(otapi_headers_dir) $(AM_CPPFLAGS) -fpic
 
@@ -411,16 +424,15 @@ createmint_CPPFLAGS		+=	-DOT_ZMQ_MODE
 endif
 
 
-#### OT API JAVA
-
 if WANT_JAVA
 lib_LTLIBRARIES			+=	libotapi-java.la
 endif
 
-libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx
+libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx		\
+					swig/otapi/OTAPI-java.h
 
-libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
-					$(JNI_CPPFLAGS)			\
+libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)				\
+					$(JNI_CPPFLAGS)				\
 					-I$(otapi_headers_dir)
 
 libotapi_java_la_LIBADD 	=	libotapi.la libot.la
@@ -461,7 +473,8 @@ if WANT_PHP
 lib_LTLIBRARIES			+=	libotapi-php.la
 endif
 
-libotapi_php_la_SOURCES		=	swig/otapi/OTAPI-php.cpp
+libotapi_php_la_SOURCES		=	swig/otapi/OTAPI-php.cpp	\
+					swig/otapi/OTAPI-php.h
 
 libotapi_php_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					-I$(otapi_headers_dir)		\
@@ -485,7 +498,8 @@ if WANT_PYTHON
 lib_LTLIBRARIES			+=	_otapi.la
 endif
 
-_otapi_la_SOURCES		=	swig/otapi/OTAPI-python.cxx
+_otapi_la_SOURCES		=	swig/otapi/OTAPI-python.cxx	\
+					swig/otapi/OTAPI-python.h
 
 _otapi_la_CPPFLAGS		= 	$(AM_CPPFLAGS)  -fpic           \
 					$(PYTHON_CPPFLAGS)              \
@@ -520,15 +534,13 @@ dist_bin_SCRIPTS		=	scripts/opentxs
 
 #### OT SCRIPT HEADERS
 
-scriptheaderdir			=	$(pkglibdir)
-dist_scriptheader_SCRIPTS	=	scripts/ot/otapi.ot		\
+dist_pkglib_SCRIPTS		=	scripts/ot/otapi.ot		\
 					scripts/ot/ot_made_easy.ot	\
 					scripts/ot/ot_utility.ot
 
 #### OT SCRIPTS
 
-samplesdir			=	$(pkglibdir)/scripts/samples
-dist_samples_SCRIPTS		=	scripts/samples/accept_inbox.ot			\
+nobase_dist_pkglib_SCRIPTS	=	scripts/samples/accept_inbox.ot			\
 					scripts/samples/add_signature.ot		\
 					scripts/samples/args.ot				\
 					scripts/samples/cancel_offer.ot			\
@@ -563,31 +575,25 @@ dist_samples_SCRIPTS		=	scripts/samples/accept_inbox.ot			\
 					scripts/samples/stat.ot				\
 					scripts/samples/time.ot				\
 					scripts/samples/verify_signature.ot		\
-					scripts/samples/write_cheque.ot
-dist_samples_DATA		=	scripts/samples/README.txt
-
-smartcontractsdir		=	$(pkglibdir)/scripts/smartcontracts
-dist_smartcontracts_SCRIPTS	=	scripts/smartcontracts/create_smartcontract.ot
-dist_smartcontracts_DATA	=	scripts/smartcontracts/readme.txt
-
-escrowdir			=	$(pkglibdir)/scripts/smartcontracts/escrow
-dist_escrow_SCRIPTS		=	scripts/smartcontracts/escrow/activate_escrow.ot		\
+					scripts/samples/write_cheque.ot			\
+					scripts/smartcontracts/create_smartcontract.ot			\
+					scripts/smartcontracts/escrow/activate_escrow.ot		\
 					scripts/smartcontracts/escrow/create_escrow.ot			\
 					scripts/smartcontracts/escrow/sign_escrow_as_alice.ot		\
 					scripts/smartcontracts/escrow/sign_escrow_as_bob.ot		\
-					scripts/smartcontracts/escrow/sign_escrow_as_judge_judy.ot
-dist_escrow_DATA		=	scripts/smartcontracts/escrow/README.txt
-
-two_way_tradedir		=	$(pkglibdir)/scripts/smartcontracts/two_way_trade
-dist_two_way_trade_SCRIPTS	=	scripts/smartcontracts/two_way_trade/activate_two_way_trade.ot	\
+					scripts/smartcontracts/escrow/sign_escrow_as_judge_judy.ot	\
+					scripts/smartcontracts/two_way_trade/activate_two_way_trade.ot	\
 					scripts/smartcontracts/two_way_trade/create_two_way_trade.ot	\
 					scripts/smartcontracts/two_way_trade/sign_trade_as_alice.ot	\
-					scripts/smartcontracts/two_way_trade/sign_trade_as_bob.ot
-dist_two_way_trade_DATA		=	scripts/smartcontracts/two_way_trade/README.txt
+					scripts/smartcontracts/two_way_trade/sign_trade_as_bob.ot	\
+					scripts/util/resync.ot
 
-utildir				=	$(pkglibdir)/scripts/util
-dist_util_SCRIPTS		=	scripts/util/resync.ot
-dist_util_DATA			=	scripts/util/README.txt
+nobase_dist_pkglib_DATA		=	scripts/README.txt				\
+					scripts/samples/README.txt			\
+					scripts/smartcontracts/readme.txt		\
+					scripts/smartcontracts/escrow/README.txt	\
+					scripts/smartcontracts/two_way_trade/README.txt	\
+					scripts/util/README.txt
 
 
 #### OT docs, licences, info, etc.

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,8 @@ AM_CPPFLAGS = 			$(common_includes)				\
 				-O0						\
 				--param ssp-buffer-size=4
 
+AM_LDFLAGS = 			$(DEPS_LDFLAGS)
+
 ## WARNING FLAGS ###
 
 if WARNINGS
@@ -31,29 +33,12 @@ endif
 ## RELEASE FLAGS ###
 
 if RELEASE
-AM_CPPFLAGS +=		-Wall						\
+AM_CPPFLAGS +=			-Wall						\
 				-D_FORTIFY_SOURCE=2				\
 				-fstack-protector-all				\
 				-fstack-check					\
 				-Wstack-protector
 endif
-
-
-
-AM_LDFLAGS = 			$(DEPS_LDFLAGS)
-
-EXTRA_DIST =			docs/GETTING-STARTED.txt			\
-				docs/INSTALL-Android.txt			\
-				docs/INSTALL-Fedora.txt				\
-				docs/INSTALL-Ubuntu.t				\
-				docs/INSTALL-OSX-Homebrew.txt			\
-				docs/INSTALL-Windows.txt			\
-				docs/LICENSE-AND-CREDITS.txt			\
-				PUBKEY-FellowTraveler.asc			\
-				README.md docs/SSL-NOTES.txt			\
-				docs/WIPE-USERS-ACCOUNTS.txt			\
-				VERSION
-
 
 ####################################################################
 
@@ -221,7 +206,7 @@ otlib_headers =			include/otlib/anyoption.h			\
 
 otlib_sources_dir = 		$(ot_source_dir)/otlib
 
-otlib_sources =			src/otlib/anyoption.cpp				\
+otlib_sources     =		src/otlib/anyoption.cpp				\
 				src/otlib/Bitcoin.pb.cpp			\
 				src/otlib/easyzlib.c				\
 				src/otlib/Generics.pb.cpp			\
@@ -278,30 +263,33 @@ otlib_sources =			src/otlib/anyoption.cpp				\
 
 ####	OT Server
 
-otserver_headers_dir =	$(ot_include_dir)/otserver
+otserver_headers_dir	=	$(ot_include_dir)/otserver
 
-otserver_headers =      include/otserver/main.h                 \
-                        include/otserver/OTClientConnection.h	\
-                        include/otserver/OTServer.h
+otserver_headers	= 	include/otserver/main.h				\
+				include/otserver/OTClientConnection.h		\
+				include/otserver/OTServer.h
 
-otserver_sources_dir =  $(ot_source_dir)/otserver
+otserver_sources_dir	=	$(ot_source_dir)/otserver
 
-otserver_sources     =  src/otserver/OTClientConnection.cpp		\
-                        src/otserver/OTServer.cpp
+otserver_sources	=	src/otserver/OTClientConnection.cpp		\
+				src/otserver/OTServer.cpp
 
 ####	Simple Ini
 
-simpleini_headers_dir =		$(ot_include_dir)/simpleini
-simpleini_headers     =		include/simpleini/ConvertUTF.h			\
-                            include/simpleini/SimpleIni.h
-simpleini_sources_dir = 	$(ot_source_dir)/simpleini
-simpleini_sources     =		src/simpleini/ConvertUTF.cpp			\
-                            src/simpleini/snippets.cpp
+simpleini_headers_dir	=	$(ot_include_dir)/simpleini
+
+simpleini_headers	=	include/simpleini/ConvertUTF.h			\
+				include/simpleini/SimpleIni.h
+
+simpleini_sources_dir	= 	$(ot_source_dir)/simpleini
+
+simpleini_sources	=	src/simpleini/ConvertUTF.cpp			\
+				src/simpleini/snippets.cpp
 
 
 ####	OT Create Mint
 
-createmint_sources_dir =    $(ot_source_dir)/createmint
+createmint_sources_dir	=	$(ot_source_dir)/createmint
 
 ####################################################################
 
@@ -310,95 +298,95 @@ createmint_sources_dir =    $(ot_source_dir)/createmint
 ## Open Transactions Lib #
 ##########################
 
-lib_LTLIBRARIES =		libot.la				\
-				libotapi.la				\
-				libbigint.la				\
-				libirrxml.la				\
+lib_LTLIBRARIES		=	libot.la					\
+				libotapi.la					\
+				libbigint.la					\
+				libirrxml.la					\
 				liblucre.la
 
 ####	LIB BigInt
 
-libbigint_la_SOURCES =		$(bigint_sources) $(bigint_headers)
-libbigint_la_CPPFLAGS =		-I$(bigint_headers_dir) $(DEPS_CFLAGS) -fpic
-libbigint_la_LDFLAGS =		-static
+libbigint_la_SOURCES	=	$(bigint_sources) $(bigint_headers)
+libbigint_la_CPPFLAGS	=	-I$(bigint_headers_dir) $(DEPS_CFLAGS) -fpic
+libbigint_la_LDFLAGS	=	-static
 
 ####	LIB IrrXML
 
-libirrxml_la_SOURCES =		$(irrxml_sources) $(irrxml_headers)
-libirrxml_la_CPPFLAGS =		-I$(irrxml_headers_dir) $(DEPS_CFLAGS) -fpic
-libirrxml_la_LDFLAGS =		-static
+libirrxml_la_SOURCES	=	$(irrxml_sources) $(irrxml_headers)
+libirrxml_la_CPPFLAGS	=	-I$(irrxml_headers_dir) $(DEPS_CFLAGS) -fpic
+libirrxml_la_LDFLAGS	=	-static
 
 ####	LIB Lucre
 
-liblucre_la_SOURCES =		$(lucre_sources) $(lucre_headers)
-liblucre_la_CPPFLAGS =		-I$(lucre_headers_dir) $(DEPS_CFLAGS) -fpic
-liblucre_la_LDFLAGS =		-static
+liblucre_la_SOURCES	=	$(lucre_sources) $(lucre_headers)
+liblucre_la_CPPFLAGS	=	-I$(lucre_headers_dir) $(DEPS_CFLAGS) -fpic
+liblucre_la_LDFLAGS	=	-static
 
 
 ####	LIB OT
 
-libot_la_SOURCES =		$(otlib_sources) $(otlib_headers)
+libot_la_SOURCES	=	$(otlib_sources) $(otlib_headers)
 
-libot_la_CPPFLAGS = 		$(AM_CPPFLAGS)
+libot_la_CPPFLAGS	=	$(AM_CPPFLAGS)
 
-libot_la_LIBADD =		$(DEPS_LIBS)				\
+libot_la_LIBADD		=	$(DEPS_LIBS)				\
 				$(BOOST_LDFLAGS)			\
 				$(BOOST_THREAD_LIB)			\
 				libbigint.la libirrxml.la liblucre.la
 
-libot_la_DEPENDENCIES =		libbigint.la libirrxml.la liblucre.la
+libot_la_DEPENDENCIES	=	libbigint.la libirrxml.la liblucre.la
 
-libot_la_LDFLAGS =		--no-undefined
+libot_la_LDFLAGS	=	--no-undefined
 
 
 ####	 LIB OT API
 
-libotapi_la_SOURCES =		$(otapi_sources) $(otapi_headers)
+libotapi_la_SOURCES	=	$(otapi_sources) $(otapi_headers)
 
-libotapi_la_CPPFLAGS =		-I$(otapi_headers_dir) $(AM_CPPFLAGS) -fpic
+libotapi_la_CPPFLAGS	=	-I$(otapi_headers_dir) $(AM_CPPFLAGS) -fpic
 
-libotapi_la_LIBADD =		libot.la
-libotapi_la_DEPENDENCIES =	libot.la
+libotapi_la_LIBADD	=	libot.la
+libotapi_la_DEPENDENCIES=	libot.la
 
-libotapi_la_LDFLAGS =		-static
+libotapi_la_LDFLAGS	=	-static
 
 
-####	Global Hedders
+####	Global Headers
 
-pkginclude_HEADERS =		$(otlib_headers)
+pkginclude_HEADERS	=	$(otlib_headers)
 
 
 ##########################
 ## Open Transactions Bin #
 ##########################
 
-bin_PROGRAMS =	ot					\
-				otserver			\
+bin_PROGRAMS		=	ot					\
+				otserver				\
 				createmint
 
 ####	OT
 
-ot_SOURCES =			$(ot_sources) $(otapi_headers)
-ot_CPPFLAGS =			-I$(otapi_headers_dir) $(AM_CPPFLAGS) -fpic
-ot_LDADD =              libotapi.la libot.la
-ot_DEPENDENCIES =		libotapi.la libot.la
+ot_SOURCES		=	$(ot_sources) $(otapi_headers)
+ot_CPPFLAGS		=	-I$(otapi_headers_dir) $(AM_CPPFLAGS) -fpic
+ot_LDADD		=	libotapi.la libot.la
+ot_DEPENDENCIES		=	libotapi.la libot.la
 
 
 ####	OT Server
 
-otserver_SOURCES =		$(otserver_sources) $(otserver_headers)
-otserver_CPPFLAGS =		-I$(otserver_headers_dir) $(AM_CPPFLAGS)
-otserver_LDADD =		libot.la
-otserver_DEPENDENCIES =	libot.la
+otserver_SOURCES	=	$(otserver_sources) $(otserver_headers)
+otserver_CPPFLAGS	=	-I$(otserver_headers_dir) $(AM_CPPFLAGS)
+otserver_LDADD		=	libot.la
+otserver_DEPENDENCIES	=	libot.la
 
 
 ####	Createmint  (includes files from OT Server)
 
-createmint_SOURCES  =		$(otserver_sources)  \
+createmint_SOURCES	=	$(otserver_sources)			\
 				$(otserver_headers)
 
-createmint_CPPFLAGS =		-I$(otserver_headers_dir) $(AM_CPPFLAGS)
-createmint_LDADD    =		libot.la
+createmint_CPPFLAGS	=	-I$(otserver_headers_dir) $(AM_CPPFLAGS)
+createmint_LDADD	=	libot.la
 createmint_DEPENDENCIES =	libot.la
 
 
@@ -411,14 +399,14 @@ createmint_DEPENDENCIES =	libot.la
 
 if TRANSPORT_ZMQ
 
-libotapi_la_CPPFLAGS +=		-DOT_ZMQ_MODE
-ot_CPPFLAGS +=			-DOT_ZMQ_MODE
+libotapi_la_CPPFLAGS		+=	-DOT_ZMQ_MODE
+ot_CPPFLAGS			+=	-DOT_ZMQ_MODE
 
-otserver_SOURCES +=		src/otserver/xmlrpcxx_server.cpp
-otserver_CPPFLAGS +=		-DOT_ZMQ_MODE
+otserver_SOURCES		+=	src/otserver/xmlrpcxx_server.cpp
+otserver_CPPFLAGS		+=	-DOT_ZMQ_MODE
 
-createmint_SOURCES +=		src/createmint/main.cpp
-createmint_CPPFLAGS +=		-DOT_ZMQ_MODE
+createmint_SOURCES		+=	src/createmint/main.cpp
+createmint_CPPFLAGS		+=	-DOT_ZMQ_MODE
 
 endif
 
@@ -426,108 +414,193 @@ endif
 #### OT API JAVA
 
 if WANT_JAVA
-lib_LTLIBRARIES +=			libotapi-java.la
+lib_LTLIBRARIES			+=	libotapi-java.la
 endif
 
-libotapi_java_la_SOURCES =		swig/otapi/OTAPI-java.cxx
+libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx
 
-libotapi_java_la_CPPFLAGS =		$(AM_CPPFLAGS)			\
+libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					$(JNI_CPPFLAGS)			\
 					-I$(otapi_headers_dir)
 
-libotapi_java_la_LIBADD =		libotapi.la libot.la
-libotapi_java_la_DEPENDENCIES =		libotapi.la libot.la
+libotapi_java_la_LIBADD 	=	libotapi.la libot.la
+libotapi_java_la_DEPENDENCIES 	=	libotapi.la libot.la
 
-libotapi_java_la_LDFLAGS =		--no-undefined
+libotapi_java_la_LDFLAGS 	=	--no-undefined
 
 if TRANSPORT_ZMQ
-libotapi_java_la_CPPFLAGS +=		-DOT_ZMQ_MODE
+libotapi_java_la_CPPFLAGS 	+=	-DOT_ZMQ_MODE
 endif
 
 
 #### OT API PERL5
 
 if WANT_PERL5
-lib_LTLIBRARIES +=			libotapi-perl5.la
+lib_LTLIBRARIES 		+=	libotapi-perl5.la
 endif
 
-libotapi_perl5_la_SOURCES =		swig/otapi/OTAPI-perl5.cxx
-libotapi_perl5_la_CPPFLAGS =		$(AM_CPPFLAGS)			\
+libotapi_perl5_la_SOURCES	=	swig/otapi/OTAPI-perl5.cxx
+libotapi_perl5_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					$(PERL_EXT_CPPFLAGS)		\
 					-I$(otapi_headers_dir)		\
 					-I$(PERL_EXT_INC)
 
-libotapi_perl5_la_LIBADD =		libotapi.la libot.la
-libotapi_perl5_la_DEPENDENCIES =	libotapi.la libot.la
+libotapi_perl5_la_LIBADD	=	libotapi.la libot.la
+libotapi_perl5_la_DEPENDENCIES	=	libotapi.la libot.la
 
-libotapi_perl5_la_LDFLAGS =		--no-undefined			\
+libotapi_perl5_la_LDFLAGS	=	--no-undefined			\
 					$(PERL_EXT_LDFLAGS)
 if TRANSPORT_ZMQ
-libotapi_perl5_la_CPPFLAGS +=		-DOT_ZMQ_MODE
+libotapi_perl5_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
 endif
 
 
 #### OT API PHP
 
 if WANT_PHP
-lib_LTLIBRARIES +=			libotapi-php.la
+lib_LTLIBRARIES			+=	libotapi-php.la
 endif
 
-libotapi_php_la_SOURCES =		swig/otapi/OTAPI-php.cpp
+libotapi_php_la_SOURCES		=	swig/otapi/OTAPI-php.cpp
 
-libotapi_php_la_CPPFLAGS =		$(AM_CPPFLAGS)			\
+libotapi_php_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					-I$(otapi_headers_dir)		\
 					-I$(top_srcdir)/swig/glue/php	\
 					$(PHP_INCLUDES)
 
-libotapi_php_la_LIBADD =		libotapi.la libot.la
-libotapi_php_la_DEPENDENCIES =		libotapi.la libot.la
+libotapi_php_la_LIBADD		=	libotapi.la libot.la
+libotapi_php_la_DEPENDENCIES	=	libotapi.la libot.la
 
-libotapi_php_la_LDFLAGS =		--no-undefined			\
+libotapi_php_la_LDFLAGS		=	--no-undefined			\
 					$(PHP_LDFLAGS)
 
 if TRANSPORT_ZMQ
-libotapi_php_la_CPPFLAGS +=		-DOT_ZMQ_MODE
+libotapi_php_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
 endif
 
 
 #### OT API PYTHON
 
 if WANT_PYTHON
-lib_LTLIBRARIES +=                      _otapi.la
+lib_LTLIBRARIES			+=	_otapi.la
 endif
 
-_otapi_la_SOURCES =             	swig/otapi/OTAPI-python.cxx
+_otapi_la_SOURCES		=	swig/otapi/OTAPI-python.cxx
 
-_otapi_la_CPPFLAGS =            	$(AM_CPPFLAGS)  -fpic           \
-                                        $(PYTHON_CPPFLAGS)              \
-                                        -I$(otapi_headers_dir)          \
-                                        $(PYTHON_EXTRA_LIBS)
+_otapi_la_CPPFLAGS		= 	$(AM_CPPFLAGS)  -fpic           \
+					$(PYTHON_CPPFLAGS)              \
+					-I$(otapi_headers_dir)          \
+					$(PYTHON_EXTRA_LIBS)
 
 
-_otapi_la_LIBADD =              	libotapi.la libot.la
-_otapi_la_DEPENDENCIES =        	libotapi.la libot.la
+_otapi_la_LIBADD		=	libotapi.la libot.la
+_otapi_la_DEPENDENCIES		= 	libotapi.la libot.la
 
-_otapi_la_LDFLAGS =             	--no-undefined                  \
-                                        -module -avoid-version          \
-                                        $(PYTHON_LDFLAGS)               \
-                                        $(PYTHON_EXTRA_LDFLAGS)
+_otapi_la_LDFLAGS		=	--no-undefined                  \
+					-module -avoid-version          \
+					$(PYTHON_LDFLAGS)               \
+					$(PYTHON_EXTRA_LDFLAGS)
 
 if TRANSPORT_ZMQ
-_otapi_la_CPPFLAGS +=			-DOT_ZMQ_MODE
+_otapi_la_CPPFLAGS		+=	-DOT_ZMQ_MODE
 endif
 
 
 
 
+###########################################################################
 
+#######################################
+## Open-Transactions Install Extras  ##
+#######################################
+
+#### OpenTXS script CLI utility
 
 dist_bin_SCRIPTS		=	scripts/opentxs
 
-                    
-                    
-                    
-                    
-                    
-                    
-                    
+#### OT SCRIPT HEADERS
+
+scriptheaderdir			=	$(pkglibdir)
+dist_scriptheader_SCRIPTS	=	scripts/ot/otapi.ot		\
+					scripts/ot/ot_made_easy.ot	\
+					scripts/ot/ot_utility.ot
+
+#### OT SCRIPTS
+
+samplesdir			=	$(pkglibdir)/scripts/samples
+dist_samples_SCRIPTS		=	scripts/samples/accept_inbox.ot			\
+					scripts/samples/add_signature.ot		\
+					scripts/samples/args.ot				\
+					scripts/samples/cancel_offer.ot			\
+					scripts/samples/cancel_plan.ot			\
+					scripts/samples/check_user.ot			\
+					scripts/samples/create_asset_acct.ot		\
+					scripts/samples/create_asset_contract.ot	\
+					scripts/samples/create_nym.ot			\
+					scripts/samples/create_offer.ot			\
+					scripts/samples/create_server_contract.ot	\
+					scripts/samples/create_symmetric_key.ot		\
+					scripts/samples/decode.ot			\
+					scripts/samples/decrypt.ot			\
+					scripts/samples/dl_acct_files.ot		\
+					scripts/samples/dl_contract.ot			\
+					scripts/samples/encode.ot			\
+					scripts/samples/encrypt.ot			\
+					scripts/samples/input_multiline.ot		\
+					scripts/samples/input_oneline.ot		\
+					scripts/samples/issue_asset.ot			\
+					scripts/samples/password_decrypt.ot		\
+					scripts/samples/password_encrypt.ot		\
+					scripts/samples/register_nym.ot			\
+					scripts/samples/send_transfer.ot		\
+					scripts/samples/send_user_msg.ot		\
+					scripts/samples/show_acct.ot			\
+					scripts/samples/show_balance.ot			\
+					scripts/samples/show_inbox.ot			\
+					scripts/samples/show_mint.ot			\
+					scripts/samples/show_outbox.ot			\
+					scripts/samples/sign_contract.ot		\
+					scripts/samples/stat.ot				\
+					scripts/samples/time.ot				\
+					scripts/samples/verify_signature.ot		\
+					scripts/samples/write_cheque.ot
+dist_samples_DATA		=	scripts/samples/README.txt
+
+smartcontractsdir		=	$(pkglibdir)/scripts/smartcontracts
+dist_smartcontracts_SCRIPTS	=	scripts/smartcontracts/create_smartcontract.ot
+dist_smartcontracts_DATA	=	scripts/smartcontracts/readme.txt
+
+escrowdir			=	$(pkglibdir)/scripts/smartcontracts/escrow
+dist_escrow_SCRIPTS		=	scripts/smartcontracts/escrow/activate_escrow.ot		\
+					scripts/smartcontracts/escrow/create_escrow.ot			\
+					scripts/smartcontracts/escrow/sign_escrow_as_alice.ot		\
+					scripts/smartcontracts/escrow/sign_escrow_as_bob.ot		\
+					scripts/smartcontracts/escrow/sign_escrow_as_judge_judy.ot
+dist_escrow_DATA		=	scripts/smartcontracts/escrow/README.txt
+
+two_way_tradedir		=	$(pkglibdir)/scripts/smartcontracts/two_way_trade
+dist_two_way_trade_SCRIPTS	=	scripts/smartcontracts/two_way_trade/activate_two_way_trade.ot	\
+					scripts/smartcontracts/two_way_trade/create_two_way_trade.ot	\
+					scripts/smartcontracts/two_way_trade/sign_trade_as_alice.ot	\
+					scripts/smartcontracts/two_way_trade/sign_trade_as_bob.ot
+dist_two_way_trade_DATA		=	scripts/smartcontracts/two_way_trade/README.txt
+
+utildir				=	$(pkglibdir)/scripts/util
+dist_util_SCRIPTS		=	scripts/util/resync.ot
+dist_util_DATA			=	scripts/util/README.txt
+
+
+#### OT docs, licences, info, etc.
+
+dist_doc_DATA			=	docs/GETTING-STARTED.txt	\
+					docs/INSTALL-Android.txt	\
+					docs/INSTALL-Fedora.txt		\
+					docs/INSTALL-Debian_Ubuntu.txt	\
+					docs/INSTALL-OSX-Homebrew.txt	\
+					docs/INSTALL-Windows.txt	\
+					docs/SSL-NOTES.txt		\
+					docs/WIPE-USERS-ACCOUNTS.txt	\
+					docs/LICENSE-AND-CREDITS.txt	\
+					PUBKEY-FellowTraveler.asc	\
+					README.md 			\
+					VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -521,80 +521,23 @@ endif
 
 
 
-
 ###########################################################################
 
 #######################################
 ## Open-Transactions Install Extras  ##
 #######################################
 
+
 #### OpenTXS script CLI utility
 
 dist_bin_SCRIPTS		=	scripts/opentxs
 
-#### OT SCRIPT HEADERS
+#### OT script HEADERS
 
-dist_pkglib_SCRIPTS		=	scripts/ot/otapi.ot		\
+dist_pkglib_SCRIPTS		=	scripts/ot/ot_commands.ot	\
+					scripts/ot/otapi.ot		\
 					scripts/ot/ot_made_easy.ot	\
 					scripts/ot/ot_utility.ot
-
-#### OT SCRIPTS
-
-nobase_dist_pkglib_SCRIPTS	=	scripts/samples/accept_inbox.ot			\
-					scripts/samples/add_signature.ot		\
-					scripts/samples/args.ot				\
-					scripts/samples/cancel_offer.ot			\
-					scripts/samples/cancel_plan.ot			\
-					scripts/samples/check_user.ot			\
-					scripts/samples/create_asset_acct.ot		\
-					scripts/samples/create_asset_contract.ot	\
-					scripts/samples/create_nym.ot			\
-					scripts/samples/create_offer.ot			\
-					scripts/samples/create_server_contract.ot	\
-					scripts/samples/create_symmetric_key.ot		\
-					scripts/samples/decode.ot			\
-					scripts/samples/decrypt.ot			\
-					scripts/samples/dl_acct_files.ot		\
-					scripts/samples/dl_contract.ot			\
-					scripts/samples/encode.ot			\
-					scripts/samples/encrypt.ot			\
-					scripts/samples/input_multiline.ot		\
-					scripts/samples/input_oneline.ot		\
-					scripts/samples/issue_asset.ot			\
-					scripts/samples/password_decrypt.ot		\
-					scripts/samples/password_encrypt.ot		\
-					scripts/samples/register_nym.ot			\
-					scripts/samples/send_transfer.ot		\
-					scripts/samples/send_user_msg.ot		\
-					scripts/samples/show_acct.ot			\
-					scripts/samples/show_balance.ot			\
-					scripts/samples/show_inbox.ot			\
-					scripts/samples/show_mint.ot			\
-					scripts/samples/show_outbox.ot			\
-					scripts/samples/sign_contract.ot		\
-					scripts/samples/stat.ot				\
-					scripts/samples/time.ot				\
-					scripts/samples/verify_signature.ot		\
-					scripts/samples/write_cheque.ot			\
-					scripts/smartcontracts/create_smartcontract.ot			\
-					scripts/smartcontracts/escrow/activate_escrow.ot		\
-					scripts/smartcontracts/escrow/create_escrow.ot			\
-					scripts/smartcontracts/escrow/sign_escrow_as_alice.ot		\
-					scripts/smartcontracts/escrow/sign_escrow_as_bob.ot		\
-					scripts/smartcontracts/escrow/sign_escrow_as_judge_judy.ot	\
-					scripts/smartcontracts/two_way_trade/activate_two_way_trade.ot	\
-					scripts/smartcontracts/two_way_trade/create_two_way_trade.ot	\
-					scripts/smartcontracts/two_way_trade/sign_trade_as_alice.ot	\
-					scripts/smartcontracts/two_way_trade/sign_trade_as_bob.ot	\
-					scripts/util/resync.ot
-
-nobase_dist_pkglib_DATA		=	scripts/README.txt				\
-					scripts/samples/README.txt			\
-					scripts/smartcontracts/readme.txt		\
-					scripts/smartcontracts/escrow/README.txt	\
-					scripts/smartcontracts/two_way_trade/README.txt	\
-					scripts/util/README.txt
-
 
 #### OT docs, licences, info, etc.
 
@@ -610,3 +553,11 @@ dist_doc_DATA			=	docs/GETTING-STARTED.txt	\
 					PUBKEY-FellowTraveler.asc	\
 					README.md 			\
 					VERSION
+
+nobase_dist_doc_DATA		=	sample-data/ot-sample-data-clean/ot_init.cfg				\
+					sample-data/ot-sample-data-clean/client.cfg				\
+					sample-data/ot-sample-data-clean/CLIENT-COMMANDS.txt			\
+					sample-data/ot-sample-data-clean/command-line-ot.opt			\
+					sample-data/ot-sample-data-clean/client_data/LICENSE-AND-CREDITS.txt	\
+					sample-data/ot-sample-data-clean/server.cfg				\
+					sample-data/ot-sample-data-clean/server_data/notaryServer.xml

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Open-Transactions], [0.80.0], [Fellow-Traveler], [Open-Transactions], [https://github.com/FellowTraveler/Open-Transactions])
+AC_INIT([opentxs], [0.82.c], [Fellow-Traveler], [opentxs], [https://github.com/FellowTraveler/Open-Transactions])
 AC_PREREQ(2.61)
 LT_PREREQ([2.2.4])
 AC_CONFIG_AUX_DIR(build-aux)

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([opentxs], [0.82.c], [Fellow-Traveler], [opentxs], [https://github.com/FellowTraveler/Open-Transactions])
+AC_INIT([opentxs], [0.82.h], [Fellow-Traveler], [opentxs], [https://github.com/FellowTraveler/Open-Transactions])
 AC_PREREQ(2.61)
 LT_PREREQ([2.2.4])
 AC_CONFIG_AUX_DIR(build-aux)

--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,14 @@ AC_PREREQ(2.61)
 LT_PREREQ([2.2.4])
 AC_CONFIG_AUX_DIR(build-aux)
 AM_INIT_AUTOMAKE([1.10 foreign])
+AC_CONFIG_FILES([Makefile])
+
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 LT_INIT([dlopen])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_SRCDIR([src/ot/main.cpp])
 
 : ${CXXFLAGS=""}
 : ${CFLAGS=""}
@@ -16,6 +19,7 @@ PKG_PROG_PKG_CONFIG([0.25])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
+
 AX_BOOST_BASE([1.25.0])
 AX_BOOST_THREAD
 
@@ -41,8 +45,6 @@ AS_IF(	[test "$with_transport" == zmq],
 	[PKG_CHECK_MODULES(
 		[DEPS],
 		[protobuf >= 2.4.1 openssl >= 1.0.0 chaiscript >= 3.1.0 libzmq])])
-
-AC_CONFIG_SRCDIR([src/otlib])
 
 
 ##### MsgPack #####
@@ -175,7 +177,4 @@ if (test "x$with_python" == "xyes"); then
 
 fi
 
-
-
-AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/docs/INSTALL-Debian_Ubuntu.txt
+++ b/docs/INSTALL-Debian_Ubuntu.txt
@@ -91,17 +91,35 @@ $ make
 $ make install
 $ cd ..
 
-
-#fetch O-T and prepare your copy for build
+# setenv varibale PKG_CONFIG_PATH
 $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
+
+
+######## Download opentxs #############
+# fetch O-T and prepare your copy for build
+
+# 'stable' source tar ball method
+$ wget https://github.com/FellowTraveler/downloads/opentxs.*.tar.gz
+$ tar -zxvf opentxs.*.tar.gz
+$ cd opentxs.*.tar.gz
+$ mkdir build && cd build
+
+
+# git pull latest development source method
 $ git clone git://github.com/FellowTraveler/Open-Transactions.git
 $ cd Open-Transactions
-
 $ autoreconf -i -f
+$ mkdir build && cd build
+########################################
 
-$ mkdir -p build && cd build
 
-$ ../configure --prefix=$HOME/.local
+
+$ ../configure --prefix=$HOME/.local --with-java
+
+(NB: Default without the "--prefix=" installs sytem-wide to /usr/local 
+and will require admin priveleges for "$ sudo make install" step below.
+Also, for MoneyChanger support "--with-java" flag is needed)
+
 
 #########   Configure Options:   #########
 Enable Configuration in Release Mode:

--- a/docs/INSTALL-Fedora.txt
+++ b/docs/INSTALL-Fedora.txt
@@ -55,19 +55,34 @@ $ make
 $ make install
 $ cd ..
 
-# fetch O-T and prepare your copy for build
+# setenv varibale PKG_CONFIG_PATH
 $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
+
+
+######## Download opentxs #############
+# fetch O-T and prepare your copy for build
+
+# 'stable' source tar ball method
+$ wget https://github.com/FellowTraveler/downloads/opentxs.*.tar.gz
+$ tar -zxvf opentxs.*.tar.gz
+$ cd opentxs.*.tar.gz
+$ mkdir build && cd build
+
+
+# git pull latest development source method
 $ git clone git://github.com/FellowTraveler/Open-Transactions.git
 $ cd Open-Transactions
-$ mkdir build
 $ autoreconf -i -f
+$ mkdir build && cd build
+########################################
 
 
-# OT build
 
-$ cd build
+$ ../configure --prefix=$HOME/.local --with-java
 
-$ ../configure --prefix=$HOME/.local
+(NB: Default without the "--prefix=" installs sytem-wide to /usr/local 
+and will require admin priveleges for "$ sudo make install" step below.
+Also, for MoneyChanger support "--with-java" flag is needed)
 
 
 #########   Configure Options:   #########
@@ -96,7 +111,7 @@ Enable Configuration for SWIG Python Support:
 ##########################################
 
 
-$ make uninstall (to cleanup anthing in you .local folder)
+$ make uninstall (to cleanup anything in your .local folder)
 
 
 $ make

--- a/docs/INSTALL-MEMO-Linux.txt
+++ b/docs/INSTALL-MEMO-Linux.txt
@@ -9,22 +9,30 @@
 # Memo for upgrades/rebuilds and 'quick start' guide for OT install on 
 # generic Linux (assumes dependencies are already satisfied).
 
-# fetch OT and prepare your copy for build
-
-$ git clone git://github.com/FellowTraveler/Open-Transactions.git
-$ cd Open-Transactions
-
 # probably need to tell autoconf to look for dep packages in $HOME/.local
 # if you used the recommended install for chai, etc
-
 $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
+
+# fetch OT and prepare your copy for build
+
+# 'stable' source tar ball method
+$ wget https://github.com/FellowTraveler/downloads/opentxs.*.tar.gz
+$ tar -zxvf opentxs.*.tar.gz
+$ cd opentxs.*.tar.gz
+$ mkdir build && cd build
+
+# git pull latest development source method
+$ git clone git://github.com/FellowTraveler/Open-Transactions.git
+$ cd Open-Transactions
 $ autoreconf -i -f
 $ mkdir -p build && cd build
+
+
 $ ../configure --prefix=$HOME/.local --with-java
 
 
-$ make uninstall (to cleanup anthing in your .local dir)
+$ make uninstall (to cleanup anything in your ~/.local dir)
 
 $ make
 (can add -j2 option for speedy build)
@@ -60,7 +68,7 @@ $ java -jar $HOME/.local/jar/MoneyChanger.jar
 
 
 
-########### UPGRADE to latest OT on github ###############
+########### UPGRADE to latest dev. OT on github ###############
 
 $ cd ~/Open-Transactions
 $ git clean -x -f -d

--- a/sample-data/ot-sample-data-clean/ot_init.cfg
+++ b/sample-data/ot-sample-data-clean/ot_init.cfg
@@ -3,6 +3,7 @@
 
 [paths]
 init_path=~/.ot
+prefix_path=~/.local
 client_path=~/.ot/client_data
 server_path=~/.ot/server_data
 

--- a/sample-data/ot-sample-data/ot_init.cfg
+++ b/sample-data/ot-sample-data/ot_init.cfg
@@ -3,6 +3,7 @@
 
 [paths]
 init_path=~/.ot
+prefix_path=~/.local
 client_path=~/.ot/client_data
 server_path=~/.ot/server_data
 

--- a/src/ot/main.cpp
+++ b/src/ot/main.cpp
@@ -816,7 +816,7 @@ bool RegisterAPIWithScript(OTScript & theBaseScript)
 		pScript->chai.add(fun(&OTAPI_Wrap::Ledger_FinalizeResponse), "OT_API_Ledger_FinalizeResponse");
 		pScript->chai.add(fun(&OTAPI_Wrap::Transaction_GetType), "OT_API_Transaction_GetType");
 		
-        pScript->chai.add(fun(&OTAPI_Wrap::ReplyNotice_GetRequestNum), "OT_API_ReplyNotice_GetRequestNum");
+		pScript->chai.add(fun(&OTAPI_Wrap::ReplyNotice_GetRequestNum), "OT_API_ReplyNotice_GetRequestNum");
         
 		pScript->chai.add(fun(&OTAPI_Wrap::Transaction_GetVoucher), "OT_API_Transaction_GetVoucher");
 		pScript->chai.add(fun(&OTAPI_Wrap::Transaction_GetSuccess), "OT_API_Transaction_GetSuccess");
@@ -1015,7 +1015,7 @@ bool RegisterAPIWithScript(OTScript & theBaseScript)
 		const char * ps3	= "ot_made_easy.ot";        // todo hardcoding
 		const char * ps4	= "ot_commands.ot";         // todo hardcoding
 		const char * pss	= OTLog::ScriptFolder();	//   "scripts"
-		const char * ps     = OTLog::PathSeparator();	//   "/"
+		const char * ps		= OTLog::PathSeparator();	//   "/"
 		const char * pot	= "ot";						//   "ot"
 		
 		OTString strUseFile1, strUseFile2, strUseFile3, strUseFile4;

--- a/src/otlib/OTLog.cpp
+++ b/src/otlib/OTLog.cpp
@@ -337,7 +337,7 @@ OTString OTLog::__OTReceiptFolder			= "receipts";
 OTString OTLog::__OTNymboxFolder			= "nymbox";		
 OTString OTLog::__OTInboxFolder				= "inbox";		
 OTString OTLog::__OTOutboxFolder			= "outbox";	
-OTString OTLog::__OTPaymentInboxFolder		= "paymentInbox";		
+OTString OTLog::__OTPaymentInboxFolder			= "paymentInbox";		
 OTString OTLog::__OTRecordBoxFolder			= "recordBox";
 OTString OTLog::__OTCertFolder				= "certs";		
 OTString OTLog::__OTPubkeyFolder			= "pubkeys";
@@ -347,7 +347,7 @@ OTString OTLog::__OTSpentFolder				= "spent";
 OTString OTLog::__OTPurseFolder				= "purse";
 OTString OTLog::__OTMarketFolder			= "markets";
 OTString OTLog::__OTScriptFolder			= "scripts";
-OTString OTLog::__OTSmartContractsFolder	= "smartcontracts";
+OTString OTLog::__OTSmartContractsFolder		= "smartcontracts";
 
 
 OTString OTLog::__OTLogfile;


### PR DESCRIPTION
Linux package name 'opentxs' is used for convenience. Provides distribution source tar ball with 'easy', configure, make, make install; given dependencies are already satisfied.  Needs some more tweaks to decide exactly which header files are needed in $(prefix)/include for the OT library (some are needed for build of OT itself only), and similar for sample-data where a skeleton .ot is provided in $(prefix)/share/docs/opentxs. Future runtime generation of any needed new user data is expected.
An example source tar ball can be found here https://github.com/downloads/randy-waterhouse/opentxs/opentxs-0.82.h.tar.gz or they can be created using configure, make distcheck.
