### PR TITLE
Install docs updated, readability mods Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -371,6 +371,103 @@ libotapi_la_LDFLAGS	=	-static
 
 pkginclude_HEADERS	=	$(otlib_headers)
 
+############################
+#### OT Optional Libraries #
+############################
+
+#### OT API JAVA
+
+if WANT_JAVA
+lib_LTLIBRARIES			+=	libotapi-java.la
+endif
+
+libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx		\
+					swig/otapi/OTAPI-java.h
+
+libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)				\
+					$(JNI_CPPFLAGS)				\
+					-I$(otapi_headers_dir)
+
+libotapi_java_la_LIBADD 	=	libotapi.la libot.la
+libotapi_java_la_DEPENDENCIES 	=	libotapi.la libot.la
+
+libotapi_java_la_LDFLAGS 	=	--no-undefined
+
+if TRANSPORT_ZMQ
+libotapi_java_la_CPPFLAGS 	+=	-DOT_ZMQ_MODE
+endif
+
+#### OT API PERL5
+
+if WANT_PERL5
+lib_LTLIBRARIES 		+=	libotapi-perl5.la
+endif
+
+libotapi_perl5_la_SOURCES	=	swig/otapi/OTAPI-perl5.cxx
+libotapi_perl5_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
+					$(PERL_EXT_CPPFLAGS)		\
+					-I$(otapi_headers_dir)		\
+					-I$(PERL_EXT_INC)
+
+libotapi_perl5_la_LIBADD	=	libotapi.la libot.la
+libotapi_perl5_la_DEPENDENCIES	=	libotapi.la libot.la
+
+libotapi_perl5_la_LDFLAGS	=	--no-undefined			\
+					$(PERL_EXT_LDFLAGS)
+if TRANSPORT_ZMQ
+libotapi_perl5_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
+endif
+
+#### OT API PHP
+
+if WANT_PHP
+lib_LTLIBRARIES			+=	libotapi-php.la
+endif
+
+libotapi_php_la_SOURCES		=	swig/otapi/OTAPI-php.cpp	\
+					swig/otapi/OTAPI-php.h
+
+libotapi_php_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
+					-I$(otapi_headers_dir)		\
+					-I$(top_srcdir)/swig/glue/php	\
+					$(PHP_INCLUDES)
+
+libotapi_php_la_LIBADD		=	libotapi.la libot.la
+libotapi_php_la_DEPENDENCIES	=	libotapi.la libot.la
+
+libotapi_php_la_LDFLAGS		=	--no-undefined			\
+					$(PHP_LDFLAGS)
+
+if TRANSPORT_ZMQ
+libotapi_php_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
+endif
+
+#### OT API PYTHON
+
+if WANT_PYTHON
+lib_LTLIBRARIES			+=	_otapi.la
+endif
+
+_otapi_la_SOURCES		=	swig/otapi/OTAPI-python.cxx	\
+					swig/otapi/OTAPI-python.h
+
+_otapi_la_CPPFLAGS		= 	$(AM_CPPFLAGS)  -fpic           \
+					$(PYTHON_CPPFLAGS)              \
+					-I$(otapi_headers_dir)          \
+					$(PYTHON_EXTRA_LIBS)
+
+_otapi_la_LIBADD		=	libotapi.la libot.la
+_otapi_la_DEPENDENCIES		= 	libotapi.la libot.la
+
+_otapi_la_LDFLAGS		=	--no-undefined                  \
+					-module -avoid-version          \
+					$(PYTHON_LDFLAGS)               \
+					$(PYTHON_EXTRA_LDFLAGS)
+
+if TRANSPORT_ZMQ
+_otapi_la_CPPFLAGS		+=	-DOT_ZMQ_MODE
+endif
+
 
 ##########################
 ## Open Transactions Bin #
@@ -413,7 +510,6 @@ createmint_DEPENDENCIES =	libot.la
 ## Open Transactions Build Options #
 ####################################
 
-
 #### Transport ZMQ
 
 if TRANSPORT_ZMQ
@@ -446,105 +542,6 @@ if KEYRING_KWALLET
 libot_la_CPPFLAGS		+=	-DOT_KEYRING_KWALLET
 endif
 
-#### OT API JAVA
-
-if WANT_JAVA
-lib_LTLIBRARIES			+=	libotapi-java.la
-endif
-
-libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx		\
-					swig/otapi/OTAPI-java.h
-
-libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)				\
-					$(JNI_CPPFLAGS)				\
-					-I$(otapi_headers_dir)
-
-libotapi_java_la_LIBADD 	=	libotapi.la libot.la
-libotapi_java_la_DEPENDENCIES 	=	libotapi.la libot.la
-
-libotapi_java_la_LDFLAGS 	=	--no-undefined
-
-if TRANSPORT_ZMQ
-libotapi_java_la_CPPFLAGS 	+=	-DOT_ZMQ_MODE
-endif
-
-
-#### OT API PERL5
-
-if WANT_PERL5
-lib_LTLIBRARIES 		+=	libotapi-perl5.la
-endif
-
-libotapi_perl5_la_SOURCES	=	swig/otapi/OTAPI-perl5.cxx
-libotapi_perl5_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
-					$(PERL_EXT_CPPFLAGS)		\
-					-I$(otapi_headers_dir)		\
-					-I$(PERL_EXT_INC)
-
-libotapi_perl5_la_LIBADD	=	libotapi.la libot.la
-libotapi_perl5_la_DEPENDENCIES	=	libotapi.la libot.la
-
-libotapi_perl5_la_LDFLAGS	=	--no-undefined			\
-					$(PERL_EXT_LDFLAGS)
-if TRANSPORT_ZMQ
-libotapi_perl5_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
-endif
-
-
-#### OT API PHP
-
-if WANT_PHP
-lib_LTLIBRARIES			+=	libotapi-php.la
-endif
-
-libotapi_php_la_SOURCES		=	swig/otapi/OTAPI-php.cpp	\
-					swig/otapi/OTAPI-php.h
-
-libotapi_php_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
-					-I$(otapi_headers_dir)		\
-					-I$(top_srcdir)/swig/glue/php	\
-					$(PHP_INCLUDES)
-
-libotapi_php_la_LIBADD		=	libotapi.la libot.la
-libotapi_php_la_DEPENDENCIES	=	libotapi.la libot.la
-
-libotapi_php_la_LDFLAGS		=	--no-undefined			\
-					$(PHP_LDFLAGS)
-
-if TRANSPORT_ZMQ
-libotapi_php_la_CPPFLAGS	+=	-DOT_ZMQ_MODE
-endif
-
-
-#### OT API PYTHON
-
-if WANT_PYTHON
-lib_LTLIBRARIES			+=	_otapi.la
-endif
-
-_otapi_la_SOURCES		=	swig/otapi/OTAPI-python.cxx	\
-					swig/otapi/OTAPI-python.h
-
-_otapi_la_CPPFLAGS		= 	$(AM_CPPFLAGS)  -fpic           \
-					$(PYTHON_CPPFLAGS)              \
-					-I$(otapi_headers_dir)          \
-					$(PYTHON_EXTRA_LIBS)
-
-
-_otapi_la_LIBADD		=	libotapi.la libot.la
-_otapi_la_DEPENDENCIES		= 	libotapi.la libot.la
-
-_otapi_la_LDFLAGS		=	--no-undefined                  \
-					-module -avoid-version          \
-					$(PYTHON_LDFLAGS)               \
-					$(PYTHON_EXTRA_LDFLAGS)
-
-if TRANSPORT_ZMQ
-_otapi_la_CPPFLAGS		+=	-DOT_ZMQ_MODE
-endif
-
-
-###########################################################################
 
 #######################################
 ## Open-Transactions Install Extras  ##

--- a/Makefile.am
+++ b/Makefile.am
@@ -381,14 +381,15 @@ if WANT_JAVA
 lib_LTLIBRARIES			+=	libotapi-java.la
 endif
 
-libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx		\
+libotapi_java_la_SOURCES	=	swig/otapi/OTAPI-java.cxx	\
 					swig/otapi/OTAPI-java.h
 
-libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)				\
-					$(JNI_CPPFLAGS)				\
+libotapi_java_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
+					$(JNI_CPPFLAGS)			\
 					-I$(otapi_headers_dir)
 
-libotapi_java_la_LIBADD 	=	libotapi.la libot.la
+libotapi_java_la_LIBADD 	=	$(DEPS_LIBS)			\
+					libotapi.la libot.la
 libotapi_java_la_DEPENDENCIES 	=	libotapi.la libot.la
 
 libotapi_java_la_LDFLAGS 	=	--no-undefined
@@ -409,7 +410,8 @@ libotapi_perl5_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					-I$(otapi_headers_dir)		\
 					-I$(PERL_EXT_INC)
 
-libotapi_perl5_la_LIBADD	=	libotapi.la libot.la
+libotapi_perl5_la_LIBADD	=	$(DEPS_LIBS)			\
+					libotapi.la libot.la
 libotapi_perl5_la_DEPENDENCIES	=	libotapi.la libot.la
 
 libotapi_perl5_la_LDFLAGS	=	--no-undefined			\
@@ -432,7 +434,8 @@ libotapi_php_la_CPPFLAGS	=	$(AM_CPPFLAGS)			\
 					-I$(top_srcdir)/swig/glue/php	\
 					$(PHP_INCLUDES)
 
-libotapi_php_la_LIBADD		=	libotapi.la libot.la
+libotapi_php_la_LIBADD		=	$(DEPS_LIBS)			\
+					libotapi.la libot.la
 libotapi_php_la_DEPENDENCIES	=	libotapi.la libot.la
 
 libotapi_php_la_LDFLAGS		=	--no-undefined			\
@@ -456,7 +459,8 @@ _otapi_la_CPPFLAGS		= 	$(AM_CPPFLAGS)  -fpic           \
 					-I$(otapi_headers_dir)          \
 					$(PYTHON_EXTRA_LIBS)
 
-_otapi_la_LIBADD		=	libotapi.la libot.la
+_otapi_la_LIBADD		=	$(DEPS_LIBS)			\
+					libotapi.la libot.la
 _otapi_la_DEPENDENCIES		= 	libotapi.la libot.la
 
 _otapi_la_LDFLAGS		=	--no-undefined                  \

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AM_CONDITIONAL(	[TRANSPORT_TESTCLIENT],	[test "$with_transport" == testclient])
 
 AS_IF(	[test "$with_transport" == zmq],
 	[
-	PKG_CHECK_MODULES([ZMQDEP],[libzmq >= 2.1.9])
+	PKG_CHECK_MODULES([ZMQDEP],[libzmq >= 2.1.4])
 	AC_LANG_PUSH([C++])
 		AC_CHECK_HEADERS([zmq.hpp],
 			[],

--- a/docs/INSTALL-Debian_Ubuntu.txt
+++ b/docs/INSTALL-Debian_Ubuntu.txt
@@ -98,10 +98,11 @@ $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
 ######## Download opentxs #############
 # fetch O-T and prepare your copy for build
 
-# 'stable' source tar ball method
-$ wget https://github.com/randy-waterhouse/opentxs/downloads/opentxs.*.tar.gz
-$ tar -zxvf opentxs.*.tar.gz
-$ cd opentxs.*.tar.gz
+# 'stable' (alpha) source tar ball method
+$ wget https://github.com/randy-waterhouse/opentxs/downloads/opentxs.83.a.tar.gz
+$ tar -zxvf opentxs.83.a.tar.gz
+$ cd opentxs.83.a.tar.gz
+$ autoreconf -i -f
 $ mkdir build && cd build
 
 

--- a/docs/INSTALL-Debian_Ubuntu.txt
+++ b/docs/INSTALL-Debian_Ubuntu.txt
@@ -132,6 +132,10 @@ Enable extra (noisy) warnings with compile:
 Enable the signal handling for catching segmentation fault's (debug only):
 --enable-sighandler
 
+Enable system keyring storage of OT passwords:
+--with-keyring=ARG
+(ARG can one of gnome, kwallet, windows, mac.)
+
 # Swig API support options: #
 
 Enable Configuration for SWIG Java Support:

--- a/docs/INSTALL-Fedora.txt
+++ b/docs/INSTALL-Fedora.txt
@@ -63,9 +63,9 @@ $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
 # fetch O-T and prepare your copy for build
 
 # 'stable' source tar ball method
-$ wget https://github.com/randy-waterhouse/opentxs/downloads/opentxs.*.tar.gz
-$ tar -zxvf opentxs.*.tar.gz
-$ cd opentxs.*.tar.gz
+$ wget https://github.com/randy-waterhouse/opentxs/downloads/opentxs.83.a.tar.gz
+$ tar -zxvf opentxs.83.a.tar.gz
+$ cd opentxs.83.a.tar.gz
 $ autoreconf -i -f
 $ mkdir build && cd build
 

--- a/docs/INSTALL-Fedora.txt
+++ b/docs/INSTALL-Fedora.txt
@@ -96,6 +96,10 @@ Enable extra (noisy) warnings with compile:
 Enable the signal handling for catching segmentation fault's (debug only):
 --enable-sighandler
 
+Enable system keyring storage of OT passwords:
+--with-keyring=ARG
+(ARG can one of gnome, kwallet, windows, mac.)
+
 ### Swig API support options:  ###
 
 Enable Configuration for SWIG Java Support:

--- a/docs/INSTALL-MEMO-Linux.txt
+++ b/docs/INSTALL-MEMO-Linux.txt
@@ -7,7 +7,8 @@
 #########################################################################
 #
 # Memo for upgrades/rebuilds and 'quick start' guide for OT install on 
-# generic Linux (assumes dependencies are already satisfied).
+# generic Linux, assumes dependencies are already satisfied.
+# (NB: Intended for linux savvy users.)
 
 # probably need to tell autoconf to look for dep packages in $HOME/.local
 # if you used the recommended install for chai, etc
@@ -16,10 +17,11 @@ $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:/usr/local/lib/pkgconfig:$PK
 
 # fetch OT and prepare your copy for build
 
-# 'stable' source tar ball method
+# 'stable' (alpha) source tar ball method
 $ wget https://github.com/FellowTraveler/downloads/opentxs.*.tar.gz
 $ tar -zxvf opentxs.*.tar.gz
 $ cd opentxs.*.tar.gz
+$ autoreconf -i -f
 $ mkdir build && cd build
 
 # git pull latest development source method
@@ -61,14 +63,17 @@ $ otserver
 
 
 #### Test OT with Java test client, Moneychanger  ####
+# (Replace wildcard * with appropriate version number)
 
 # fetch FT's MoneyChanger jar and launch
-$ wget -P $HOME/.local/jar https://github.com/downloads/FellowTraveler/Moneychanger/MoneyChanger.jar
-$ java -jar $HOME/.local/jar/MoneyChanger.jar
+$ wget -P $HOME/.local/jar https://github.com/downloads/FellowTraveler/Moneychanger/MoneyChanger-*.jar
+$ java -jar $HOME/.local/jar/MoneyChanger-*.jar
 
 
 
 ########### UPGRADE to latest dev. OT on github ###############
+#
+# (NB: might need to $ make uninstall before this if configure or Makefile.am changed)
 
 $ cd ~/Open-Transactions
 $ git clean -x -f -d
@@ -76,6 +81,5 @@ $ git pull
 $ autoreconf -i -f
 $ mkdir build && cd build
 $ ../configure --prefix=$HOME/.local --with-java
-$ make uninstall
 $ make
 $ make install

--- a/docs/INSTALL-MEMO-Linux.txt
+++ b/docs/INSTALL-MEMO-Linux.txt
@@ -18,23 +18,25 @@ $ export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:/usr/local/lib/pkgconfig:$PK
 # fetch OT and prepare your copy for build
 
 # 'stable' (alpha) source tar ball method
-$ wget https://github.com/FellowTraveler/downloads/opentxs.*.tar.gz
+# (Replace wildcard * with appropriate version number)
+#
+$ wget https://github.com/randy-waterhouse/downloads/opentxs.*.tar.gz
 $ tar -zxvf opentxs.*.tar.gz
 $ cd opentxs.*.tar.gz
 $ autoreconf -i -f
 $ mkdir build && cd build
 
+
 # git pull latest development source method
+#
 $ git clone git://github.com/FellowTraveler/Open-Transactions.git
 $ cd Open-Transactions
 $ autoreconf -i -f
 $ mkdir -p build && cd build
 
+$ make uninstall (to cleanup anything in your ~/.local dir)
 
 $ ../configure --prefix=$HOME/.local --with-java
-
-
-$ make uninstall (to cleanup anything in your ~/.local dir)
 
 $ make
 (can add -j2 option for speedy build)


### PR DESCRIPTION
As the title says ... house-cleaning.
Also added downgrade on zmq version requirement to 2.1.4. This was tough one because I read the docs for zmq and tested 2.1.4 successfully. We need to have as low version number as possible to reach wider audience without having them build zmq from source ... but if it is introducing other errors we can't go to low. I'm happy 2.1.4 works.
