### PR TITLE
Present OT_PREFIX_PATH to the compiler

### DIFF
--- a/src/otlib/Makefile.am
+++ b/src/otlib/Makefile.am
@@ -10,7 +10,8 @@ opentxs_source_dir =		$(top_srcdir)/src
 common_includes		=	-I$(opentxs_include_dir)		\
 				-I$(opentxs_include_dir)/otlib		\
 				-I$(opentxs_include_dir)/containers	\
-				$(DEPS_CFLAGS)
+				$(DEPS_CFLAGS)				\
+				-DOT_PREFIX_PATH="\"${prefix}\""
 
 
 AM_CPPFLAGS		= 	$(AC_CXXFLAGS)

--- a/src/otlib/OTLog.cpp
+++ b/src/otlib/OTLog.cpp
@@ -173,10 +173,13 @@ yIh+Yp/KBzySU3inzclaAfv102/t5xi1l+GTyWHiwZxlyt5PBVglKWx/Ust9CIvN
 #define OT_APPDATA_DIR ".ot"
 #endif
 
+#ifndef OT_PREFIX_PATH
+#define OT_PREFIX_PATH "/usr/local" //default prefix_path
+#endif
+
 #define OT_INIT_CONFIG_FILENAME "ot_init.cfg"
 #define OT_HOME_DIR "."
 #define OT_CONFIG_DIR "."
-#define OT_PREFIX_PATH "/usr/local"
 #define OT_USER_SCRIPTS_DIR "scripts"
 #define OT_SCRIPTS_DIR "opentxs"
 #define OT_LIB_DIR "lib"


### PR DESCRIPTION
Variable ${prefix} is user-selectable on the configure line, default /usr/local and uses same default inside code. ot_init.cfg is written with prefix_path=OT_PREFIX_PATH on ot launch if empty.
