### PR TITLE
updated osx homebrew install instructions for latest zeromq

### DIFF
--- a/docs/INSTALL-OSX-Homebrew.txt
+++ b/docs/INSTALL-OSX-Homebrew.txt
@@ -102,6 +102,13 @@ $ make tests
 # may need root, depending on where $HOMEBREW_PREFIX points
 $ make install
 
+## CPPZMQ ##
+## 0MQ no longer includes C++ bindings by default ##
+
+$ mkdir -p ~/Scratch/Sources; cd ~/Scratch/Sources
+$ git clone git://github.com/zeromq/cppzmq.git
+$ cp cppzmq/zmq.hpp $HOMEBREW_PREFIX/include/
+
 
 ## PROTOBUF ##
 ## we must compile this ourselves##


### PR DESCRIPTION
Updated docs/INSTALL-OSX-Homebrew.txt for the current brew version of zeromq
