### PR TITLE
Sync automake VERSION with OTLog version.

### DIFF
--- a/src/otlib/Makefile.am
+++ b/src/otlib/Makefile.am
@@ -11,7 +11,8 @@ common_includes		=	-I$(opentxs_include_dir)		\
 				-I$(opentxs_include_dir)/otlib		\
 				-I$(opentxs_include_dir)/containers	\
 				$(DEPS_CFLAGS)				\
-				-DOT_PREFIX_PATH="\"${prefix}\""
+				-DOT_PREFIX_PATH="\"${prefix}\""	\
+				-DOT_VERSION="\"${VERSION}\""
 
 
 AM_CPPFLAGS		= 	$(AC_CXXFLAGS)


### PR DESCRIPTION
Get version from same source, VERSION file.
