### PR TITLE
Set global -fPIC -DPIC compiler flags gcc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,9 +396,9 @@ fi
 #####   Output to AM   #####
 
 if (test "x$acv_mesa_CLANG" == "xyes"); then
-	AC_SUBST([AC_CXXFLAGS],["-g3 -O0 $WARN_CXXFLAGS $REL_CXXFLAGS"])
+	AC_SUBST([AC_CXXFLAGS],["-g3 -O0 -fPIC $WARN_CXXFLAGS $REL_CXXFLAGS"])
 else
-	AC_SUBST([AC_CXXFLAGS],["--param ssp-buffer-size=4 $WARN_CXXFLAGS $REL_CXXFLAGS"])
+	AC_SUBST([AC_CXXFLAGS],["-fPIC -DPIC --param ssp-buffer-size=4 $WARN_CXXFLAGS $REL_CXXFLAGS"])
 fi
 
 AC_SUBST(       [DEPS_CFLAGS],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,7 @@ bin_PROGRAMS		=	ot			\
 
 ot_SOURCES		=	$(ot_sources) $(otapi_headers)
 
-ot_CXXFLAGS		=	-I$(otapi_headers_dir)	$(common_includes) -fpic
+ot_CXXFLAGS		=	-I$(otapi_headers_dir)	$(common_includes)
 
 ot_LDADD		=	otapi/libotapi.la otlib/libot.la $(DEPS_LIBS)
 ot_DEPENDENCIES		=	otapi/libotapi.la otlib/libot.la

--- a/src/otapi/Makefile.am
+++ b/src/otapi/Makefile.am
@@ -26,7 +26,7 @@ AM_CXXFLAGS		=	$(AC_CXXFLAGS)
 libotapi_la_SOURCES		=	$(otapi_sources) $(otapi_headers)	\
 					$(simpleini_headers)
 
-libotapi_la_CXXFLAGS		=	$(common_includes) -fpic
+libotapi_la_CXXFLAGS		=	$(common_includes)
 
 libotapi_la_LIBADD		=	$(otlib_build_dir)/libot.la $(DEPS_LIBS)
 libotapi_la_DEPENDENCIES	=	$(otlib_build_dir)/libot.la
@@ -107,7 +107,7 @@ endif
 _otapi_la_SOURCES		=	$(opentxs_swig_dir)/otapi/OTAPI-python.cxx	\
 					$(opentxs_swig_dir)/otapi/OTAPI-python.h
 
-_otapi_la_CXXFLAGS		= 	$(common_includes)  -fpic			\
+_otapi_la_CXXFLAGS		= 	$(common_includes)				\
 					$(PYTHON_CPPFLAGS)				\
 					$(PYTHON_EXTRA_LIBS)
 _otapi_la_LIBADD		=	libotapi.la $(otlib_build_dir)/libot.la $(DEPS_LIBS)

--- a/src/otlib/bigint/Makefile.am
+++ b/src/otlib/bigint/Makefile.am
@@ -23,6 +23,6 @@ bigint_sources		=	BigInteger.cc			\
 
 
 libbigint_la_SOURCES	=	$(bigint_sources) $(bigint_headers)
-libbigint_la_CXXFLAGS	=	-I$(bigint_headers_dir) $(DEPS_CFLAGS) -fpic
+libbigint_la_CXXFLAGS	=	-I$(bigint_headers_dir) $(DEPS_CFLAGS)
 libbigint_la_LDFLAGS	=	-static
 

--- a/src/otlib/irrxml/Makefile.am
+++ b/src/otlib/irrxml/Makefile.am
@@ -18,5 +18,5 @@ irrxml_headers		=	$(irrxml_headers_dir)/CXMLReaderImpl.h		\
 irrxml_sources		=	irrXML.cpp
 
 libirrxml_la_SOURCES	=	$(irrxml_sources) $(irrxml_headers)
-libirrxml_la_CXXFLAGS	=	-I$(irrxml_headers_dir) $(DEPS_CFLAGS) -fpic
+libirrxml_la_CXXFLAGS	=	-I$(irrxml_headers_dir) $(DEPS_CFLAGS)
 libirrxml_la_LDFLAGS	=	-static

--- a/src/otlib/lucre/Makefile.am
+++ b/src/otlib/lucre/Makefile.am
@@ -12,5 +12,5 @@ lucre_headers		=	$(lucre_headers_dir)/bank.h
 lucre_sources		=	bankimp.cpp
 
 liblucre_la_SOURCES	=	$(lucre_sources) $(lucre_headers)
-liblucre_la_CXXFLAGS	=	-I$(lucre_headers_dir) $(DEPS_CFLAGS) -fpic
+liblucre_la_CXXFLAGS	=	-I$(lucre_headers_dir) $(DEPS_CFLAGS)
 liblucre_la_LDFLAGS	=	-static

--- a/src/otlib/otext/Makefile.am
+++ b/src/otlib/otext/Makefile.am
@@ -2,6 +2,7 @@ noinst_LTLIBRARIES = libotext.la
 
 ## For now we build locally and statically link to this library as a convenience library
 
+AM_CFLAGS		=	$(AC_CXXFLAGS)
 AM_CPPFLAGS		= 	$(AC_CXXFLAGS)
 AM_CXXFLAGS		=	$(AC_CXXFLAGS)
 

--- a/src/otlib/otprotob/Makefile.am
+++ b/src/otlib/otprotob/Makefile.am
@@ -14,7 +14,7 @@ otprotob_sources	=	Bitcoin.proto		\
 				Moneychanger.proto
 
 libotprotob_la_SOURCES	=	$(otprotob_sources)
-libotprotob_la_CXXFLAGS	=	-I$(otprotob_headers_dir) $(DEPS_CFLAGS) -fpic
+libotprotob_la_CXXFLAGS	=	-I$(otprotob_headers_dir) $(DEPS_CFLAGS)
 libotprotob_la_LDFLAGS	=	-static
 
 ## Extra rules to handle *.proto as autobuild inputs


### PR DESCRIPTION
Before the flags were set only mostly through the -fpic setting in some parts of the library and by the default setting of libtool (in a platform dependent way). This change ensures that these flags are used in all circumstances and used for the whole library.

Also set -fPIC for clang compiler globally.
