### PR TITLE
Include extra headers in packaging.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ SUBDIRS			=	src
 
 dist_bin_SCRIPTS		=	scripts/opentxs
 
-#### OT script HEADERS
+#### OT SCRIPTS (headers)
 
 opentxslibdir			=	$(pkglibdir)
 

--- a/src/otlib/Makefile.am
+++ b/src/otlib/Makefile.am
@@ -8,9 +8,9 @@ opentxs_source_dir =		$(top_srcdir)/src
 ## COMMON FLAGS ###
 
 common_includes		=	-I$(opentxs_include_dir)		\
-				-I$(opentxs_include_dir)/otlib		\
+				-I$(opentxs_include_dir)/otlib	\
 				-I$(opentxs_include_dir)/containers	\
-				$(DEPS_CFLAGS)				\
+				$(DEPS_CFLAGS)			\
 				-DOT_PREFIX_PATH="\"${prefix}\""	\
 				-DOT_VERSION="\"${VERSION}\""
 
@@ -26,7 +26,7 @@ libot_la_SOURCES	=	$(otlib_sources)		\
 
 libot_la_CXXFLAGS	=	$(common_includes)
 
-libot_la_LIBADD		=	bigint/libbigint.la		\
+libot_la_LIBADD	=	bigint/libbigint.la		\
 				irrxml/libirrxml.la		\
 				lucre/liblucre.la		\
 				otprotob/libotprotob.la		\
@@ -122,23 +122,23 @@ otlib_headers_dir	=	$(opentxs_include_dir)/otlib
 
 otlib_headers		=	$(otlib_headers_dir)/constants.h		\
 				$(otlib_headers_dir)/fast_mutex.h		\
-				$(otlib_headers_dir)/ExportWrapper.h		\
 				$(otlib_headers_dir)/WinsockWrapper.h		\
-				$(otlib_headers_dir)/easyzlib.h			\
+				$(otlib_headers_dir)/easyzlib.h		\
 				$(otlib_headers_dir)/tinythread.h		\
 				$(otlib_headers_dir)/Timer.h			\
 				$(otlib_headers_ext)
 
-otlib_headers_ext	=	$(otlib_headers_dir)/stacktrace.h		\
+otlib_headers_ext	=	$(otlib_headers_dir)/ExportWrapper.h		\
+				$(otlib_headers_dir)/stacktrace.h		\
 				$(otlib_headers_dir)/OTAccount.h		\
 				$(otlib_headers_dir)/OTAgreement.h		\
 				$(otlib_headers_dir)/OTASCIIArmor.h		\
-				$(otlib_headers_dir)/OTAssetContract.h		\
-				$(otlib_headers_dir)/OTAsymmetricKey.h		\
-				$(otlib_headers_dir)/OTBasket.h			\
-				$(otlib_headers_dir)/OTBylaw.h			\
+				$(otlib_headers_dir)/OTAssetContract.h	\
+				$(otlib_headers_dir)/OTAsymmetricKey.h	\
+				$(otlib_headers_dir)/OTBasket.h		\
+				$(otlib_headers_dir)/OTBylaw.h		\
 				$(otlib_headers_dir)/OTCachedKey.h		\
-				$(otlib_headers_dir)/OTCheque.h			\
+				$(otlib_headers_dir)/OTCheque.h		\
 				$(otlib_headers_dir)/OTContract.h		\
 				$(otlib_headers_dir)/OTCredential.h		\
 				$(otlib_headers_dir)/OTCron.h			\

--- a/src/otlib/irrxml/Makefile.am
+++ b/src/otlib/irrxml/Makefile.am
@@ -5,9 +5,16 @@ noinst_LTLIBRARIES = libirrxml.la
 AM_CPPFLAGS		= 	$(AC_CXXFLAGS)
 AM_CXXFLAGS		=	$(AC_CXXFLAGS)
 
+
+libirrxml_la_SOURCES	=	$(irrxml_sources) $(irrxml_headers)
+libirrxml_la_CXXFLAGS	=	-I$(irrxml_headers_dir) $(DEPS_CFLAGS)
+libirrxml_la_LDFLAGS	=	-static
+
+irrxml_sources		=	irrXML.cpp
+
 irrxml_headers_dir	=	$(top_srcdir)/include/irrxml
 
-irrxml_headers		=	$(irrxml_headers_dir)/CXMLReaderImpl.h		\
+irrxml_headers		=	$(irrxml_headers_dir)/CXMLReaderImpl.h	\
 				$(irrxml_headers_dir)/fast_atof.h		\
 				$(irrxml_headers_dir)/heapsort.h		\
 				$(irrxml_headers_dir)/irrArray.h		\
@@ -15,8 +22,7 @@ irrxml_headers		=	$(irrxml_headers_dir)/CXMLReaderImpl.h		\
 				$(irrxml_headers_dir)/irrTypes.h		\
 				$(irrxml_headers_dir)/irrXML.h
 
-irrxml_sources		=	irrXML.cpp
 
-libirrxml_la_SOURCES	=	$(irrxml_sources) $(irrxml_headers)
-libirrxml_la_CXXFLAGS	=	-I$(irrxml_headers_dir) $(DEPS_CFLAGS)
-libirrxml_la_LDFLAGS	=	-static
+pkginclude_irrxmldir	=	$(pkgincludedir)/irrxml
+
+pkginclude_irrxml_HEADERS	=	$(irrxml_headers)


### PR DESCRIPTION
As per title. these headers got left out from original packaging because they are not part of core OT library. However, external development will need them to build other projects.
