### PR TITLE
Fix SWIG build for libotapi-perl5 support.

### DIFF
--- a/swig/buildwrappers.sh
+++ b/swig/buildwrappers.sh
@@ -7,21 +7,20 @@ if ! swig -version > /dev/null; then
     exit 1
 fi
 
-
 for x in csharp java perl5 php python ruby tcl d
 do
     echo Generating for $x ...
 
-    rm -r glue/$x
+    rm -rf glue/$x
     mkdir glue/$x
 
     # Remove existing temporary wrapper files
     for ext in cxx cpp h; do
-	if [ -f otapi/OTAPI_wrap.$ext ]; then rm otapi/OTAPI_wrap.$ext; fi
+	if [ -f otapi/OTAPI_wrap.$ext ]; then 'rm -f otapi/OTAPI_wrap.$ext'; fi
     done
 
 
-    if [ "$x" != "java" ] || [ "$x" != "csharp" ]; then
+    if [ "$x" != "java" ] && [ "$x" != "csharp" ]; then
 	echo swig -c++ -$x -outdir glue/$x otapi/OTAPI.i
 	swig -c++ -$x -outdir glue/$x otapi/OTAPI.i
     fi
@@ -30,7 +29,6 @@ do
 	echo swig -c++ -$x -package org.opentransactions.otapi -outdir glue/$x otapi/OTAPI.i
 	swig -c++ -$x -package org.opentransactions.otapi -outdir glue/$x otapi/OTAPI.i
     fi
-
 
     if [ "$x" == "csharp" ]; then
       echo swig -c++ -$x -namespace OpenTransactions.OTAPI -dllimport otapi-csharp -outdir glue/$x otapi/OTAPI.i

--- a/swig/otapi/OTAPI.i
+++ b/swig/otapi/OTAPI.i
@@ -1,7 +1,26 @@
 %module(directors="1") otapi
+
 %{
 #include <string>
 #include <map>
+%}
+
+
+#ifdef SWIGPERL
+%{
+/* Workaround perl5 global namespace pollution. Note that undefining library
+ * functions like fopen will not solve the problem on all platforms as fopen
+ * might be a macro on Windows but not necessarily on other operating systems. */
+
+#ifdef New
+  #undef New
+#endif
+%}
+#endif // SWIGPERL
+
+
+// ALL
+%{
 #include "../../include/otlib/OTAsymmetricKey.h"
 #include "../../include/otapi/OTAPI_Basic.h"
 #include "../../include/otapi/OTMadeEasy.h"
@@ -483,9 +502,6 @@ OT_IS_ELEMENT_TYPE(TradeListNym)
 
 // ------------------------------------------------------------
 #endif  // SWIGJAVA
-
-
-
 
 
 // -----------------------------------------------------------


### PR DESCRIPTION
Fixed OTAPI.i and buildwrapper.sh to generate wrapper for perl5 otapi build module that compiles.
