### PR TITLE
Next pid locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,11 @@ src/otlib/bigint/.deps/
 src/otlib/irrxml/.deps/
 src/otlib/lucre/.deps/
 src/otlib/protobOT/.deps/
+src/otlib/otext/.deps/
+src/otlib/otprotob/.deps/
+src/otlib/otprotob/*.cc
+
+.deps/
 
 # linux build noise
 *.lo

--- a/.gitignore
+++ b/.gitignore
@@ -92,15 +92,6 @@ config.status
 libtool
 stamp-h1
 src/opentxs.pc
-src/.deps/
-src/otapi/.deps/
-src/otlib/.deps/
-src/otlib/bigint/.deps/
-src/otlib/irrxml/.deps/
-src/otlib/lucre/.deps/
-src/otlib/protobOT/.deps/
-src/otlib/otext/.deps/
-src/otlib/otprotob/.deps/
 src/otlib/otprotob/*.cc
 
 .deps/

--- a/include/otapi/OTAPI.h
+++ b/include/otapi/OTAPI.h
@@ -203,7 +203,7 @@ public :
 
     ~OTAPI_Wrap();
 
-	EXPORT static OTAPI_Wrap * It();
+	EXPORT static OTAPI_Wrap * It(bool bLoadAPI=true);
 
 	EXPORT static OT_API * OTAPI();
 

--- a/include/otapi/OTAPI.h
+++ b/include/otapi/OTAPI.h
@@ -193,6 +193,7 @@ private :
 
 	static bool bInitOTApp;
 	static bool bCleanupOTApp;
+	static bool bGoingDown; // are we are going down (atexit/signals etc)
 
 	static OTAPI_Wrap * p_Wrap;
     
@@ -203,9 +204,10 @@ public :
 
     ~OTAPI_Wrap();
 
+	EXPORT static void GoingDown(); // tell wrapper to never spawn next OT_API e.g. because we are going down (atexit/signals etc)
 	EXPORT static OTAPI_Wrap * It(bool bLoadAPI=true);
 
-	EXPORT static OT_API * OTAPI();
+	EXPORT static OT_API * OTAPI(bool bLoadAPI=true);
 
 //	EXPORT static const bool & Cleanup();
 

--- a/include/otapi/OTAPI.h
+++ b/include/otapi/OTAPI.h
@@ -179,6 +179,8 @@
 #include <OTPassword.h>
 #include <OTData.h>
 
+// for manuall file operations in signal handler:
+#include <fcntl.h> 
 
 class OT_API;
 class OTServerContract;

--- a/include/otapi/OpenTransactions.h
+++ b/include/otapi/OpenTransactions.h
@@ -287,6 +287,13 @@ public:
 };
 
 
+
+void OT_API_atexit(int signal=-1); // for global signal handler - must be able to run in SIGNAL CONTEXT
+
+/**
+ We assume in few places that OT_API will be always a singleton.
+ For example in places marked with [[OT_API_singleton]] (but also more) you need to change them to make OT_API class usable in multiple instances
+*/
 class OT_API // The C++ high-level interface to the Open Transactions client-side.
 {
 
@@ -296,13 +303,15 @@ private:
 	static bool bInitOTApp;
 	static bool bCleanupOTApp;
 
+	OT_API *m_ptrInstance; // pointer to the only instance of this class (singleton - created in constructor). [[OT_API_singleton]]
+
 public:
 
 
 	EXPORT  static	bool InitOTApp();	 // Once per run. calls OTLog::Init("client");
 	EXPORT	static	bool CleanupOTApp(); // As the application shuts down gracefully...
 
-
+	static void CleanupForAtexit(int signal=-1); // to be called onexit (ctrl-C etc.) - from global handler, in SIGNAL CONTEXT 
 
 	// Member
 private:

--- a/include/otapi/OpenTransactions.h
+++ b/include/otapi/OpenTransactions.h
@@ -288,6 +288,7 @@ public:
 
 
 
+extern bool OT_API_atexit_now; // (global) are we *now* running atexit? 
 void OT_API_atexit(int signal=-1); // for global signal handler - must be able to run in SIGNAL CONTEXT
 
 /**
@@ -311,7 +312,7 @@ public:
 	EXPORT  static	bool InitOTApp();	 // Once per run. calls OTLog::Init("client");
 	EXPORT	static	bool CleanupOTApp(); // As the application shuts down gracefully...
 
-	static void CleanupForAtexit(int signal=-1); // to be called onexit (ctrl-C etc.) - from global handler, in SIGNAL CONTEXT 
+	void CleanupForAtexit(int signal=-1); // to be called onexit (ctrl-C etc.) - from global handler, in SIGNAL CONTEXT 
 
 	// Member
 private:

--- a/include/otapi/OpenTransactions.h
+++ b/include/otapi/OpenTransactions.h
@@ -321,7 +321,13 @@ private:
 	{
 	private:
 		bool m_bIsPidOpen;
-		OTString m_strPidFilePath;
+
+	  OTString m_strPidFilePath;
+		std::string m_strPidFilePath_str; // same, as std::string
+	  const char* m_strPidFilePath_cstr; // same, as cstring. not-owned, it only points to the data owned by std::string
+
+		private:
+			void set_PidFilePath(const OTString &path); // updates all versions of this string
 
 #ifdef _WIN32
 		static BOOL WINAPI ConsoleHandler(DWORD);

--- a/include/otapi/OpenTransactions.h
+++ b/include/otapi/OpenTransactions.h
@@ -322,6 +322,11 @@ private:
 	private:
 		bool m_bIsPidOpen;
 		OTString m_strPidFilePath;
+
+#ifdef _WIN32
+		static BOOL WINAPI ConsoleHandler(DWORD);
+#endif
+
 	public:
 		Pid();
 		~Pid();

--- a/include/otapi/OpenTransactions.h
+++ b/include/otapi/OpenTransactions.h
@@ -332,6 +332,7 @@ private:
 		~Pid();
 		void OpenPid(const OTString strPidFilePath);
 		void ClosePid();
+		void ClosePid_asyncsafe(); // asynce-safe (can be used in signal handler)
 		const bool IsPidOpen() const;
 	};
 

--- a/src/otapi/OTAPI.cpp
+++ b/src/otapi/OTAPI.cpp
@@ -307,11 +307,13 @@ bool OTAPI_Wrap::AppCleanup() // Call this ONLY ONCE, when your App is shutting 
 // **********************************************************************
 
 //static
-OTAPI_Wrap * OTAPI_Wrap::It()
+OTAPI_Wrap * OTAPI_Wrap::It(bool bLoadAPI/*=true*/)
 {
 	if (!OTAPI_Wrap::bCleanupOTApp)
 	{
 		if (NULL != OTAPI_Wrap::p_Wrap) return OTAPI_Wrap::p_Wrap;
+
+		if (!bLoadAPI) return false; // don't load API (for sighandler)
 
 		OTAPI_Wrap * tmpWrap = new OTAPI_Wrap();
 		if (NULL != tmpWrap)
@@ -326,10 +328,10 @@ OTAPI_Wrap * OTAPI_Wrap::It()
 		}
 	}
 	// --------------------
-    // else:
-    //
-    assert(false);
-    return NULL;
+	// else:
+	//
+	assert(false);
+	return NULL;
 }
 
 //static

--- a/src/otapi/OTAPI.cpp
+++ b/src/otapi/OTAPI.cpp
@@ -221,8 +221,8 @@ OTAPI_Wrap * OTAPI_Wrap::p_Wrap = NULL;
 
 bool OTAPI_Wrap::bInitOTApp = false;
 bool OTAPI_Wrap::bCleanupOTApp = false;
+bool OTAPI_Wrap::bGoingDown = false;
 // ---------------------------------------------------------------
-
 
 OTAPI_Wrap::OTAPI_Wrap() : p_OTAPI(NULL)
 {
@@ -256,6 +256,12 @@ OTAPI_Wrap::~OTAPI_Wrap()
     if (NULL != p_OTAPI) delete p_OTAPI; p_OTAPI = NULL;
 }
 
+
+// **********************************************************************
+
+void OTAPI_Wrap::GoingDown() { 
+	bGoingDown=1;
+}
 
 // **********************************************************************
 
@@ -313,7 +319,8 @@ OTAPI_Wrap * OTAPI_Wrap::It(bool bLoadAPI/*=true*/)
 	{
 		if (NULL != OTAPI_Wrap::p_Wrap) return OTAPI_Wrap::p_Wrap;
 
-		if (!bLoadAPI) return false; // don't load API (for sighandler)
+		if (!bLoadAPI) return NULL; // don't load API (e.g. for sighandler)
+		if (OTAPI_Wrap::bGoingDown) return NULL; // don't load API - we are going down
 
 		OTAPI_Wrap * tmpWrap = new OTAPI_Wrap();
 		if (NULL != tmpWrap)
@@ -328,16 +335,16 @@ OTAPI_Wrap * OTAPI_Wrap::It(bool bLoadAPI/*=true*/)
 		}
 	}
 	// --------------------
-	// else:
-	//
-	assert(false);
+	// else
+	
+	if (bLoadAPI) assert(false); // we are in cleanup and it's not just a question - can't create object!
 	return NULL;
 }
 
 //static
-OT_API * OTAPI_Wrap::OTAPI()
+OT_API * OTAPI_Wrap::OTAPI(bool bLoadAPI/*=true*/)
 {
-	return OTAPI_Wrap::It()->p_OTAPI;
+	return OTAPI_Wrap::It(bLoadAPI)->p_OTAPI;
 }
 
 

--- a/src/otapi/OTAPI.cpp
+++ b/src/otapi/OTAPI.cpp
@@ -344,7 +344,9 @@ OTAPI_Wrap * OTAPI_Wrap::It(bool bLoadAPI/*=true*/)
 //static
 OT_API * OTAPI_Wrap::OTAPI(bool bLoadAPI/*=true*/)
 {
-	return OTAPI_Wrap::It(bLoadAPI)->p_OTAPI;
+	OTAPI_Wrap *wrap = OTAPI_Wrap::It(bLoadAPI);
+	if (wrap) return wrap->p_OTAPI;
+	return NULL;
 }
 
 

--- a/src/otapi/OpenTransactions.cpp
+++ b/src/otapi/OpenTransactions.cpp
@@ -765,6 +765,27 @@ bool OT_API::bInitOTApp = false;
 // static
 bool OT_API::bCleanupOTApp = false;
 
+
+void OT_API_atexit(int signal) { // for global signal handler - must be able to run in SIGNAL CONTEXT
+	std::cerr << "Signal("<<signal<<"): for-atexit cleanup handler." << std::endl;
+
+	//	OTAPI_Wrap::deny_creation = true; // tell the wrapper that we are going down  // TODO
+	OT_API * ot_api = OTAPI_Wrap::It(false); // just check if OTAPI was even created yet? (and write down the address)
+	if (ot_api) { // OTAPI was created
+		std::cerr << "Signal("<<signal<<"): for-atexit: will ask existing OT_API object to cleanup." << std::endl;
+		ot_api->
+	}
+
+	std::cerr << "Signal("<<signal<<"): for-atexit cleanup handler- DONE" << std::endl;
+}
+
+void OT_API::CleanupForAtexit(int signal) {
+	std::cerr << "Signal("<<signal<<"): for-atexit cleanup method." << std::endl;
+
+
+	std::cerr << "Signal("<<signal<<"): for-atexit cleanup method- DONE" << std::endl;
+}
+
 // ------------------------------------
 
 // Call this once per run of the software. (enforced by a static value)

--- a/src/otapi/OpenTransactions.cpp
+++ b/src/otapi/OpenTransactions.cpp
@@ -1023,7 +1023,6 @@ void OT_API::Pid::OpenPid(const OTString strPidFilePath)
 			_local_add_handler(SIGINT);
 			_local_add_handler(SIGTERM);
 			_local_add_handler(SIGHUP);
-			_local_add_handler(SIGSTOP);
 		#undef _local_add_handler
 
 		OT_API_atexit_installed=1;

--- a/src/otapi/OpenTransactions.cpp
+++ b/src/otapi/OpenTransactions.cpp
@@ -973,7 +973,8 @@ bool OT_API_atexit_installed=0;  // (global - in this cpp only) is the atexit in
 
 void OT_API_signalHanlder(int signal) {
 	std::cerr << "Got signal="<<signal<<", exiting"<<std::endl;
-	exit(signal);
+	OT_API_atexit(signal); // try to call it directly so it knows the signal that cuased it
+	exit(signal); // called also from here
 }
 
 void OT_API::Pid::OpenPid(const OTString strPidFilePath)

--- a/src/otapi/OpenTransactions.cpp
+++ b/src/otapi/OpenTransactions.cpp
@@ -774,28 +774,22 @@ void OT_API_atexit() {
 
 void OT_API_atexit(int signal) { // for global signal handler - must be able to run in SIGNAL CONTEXT
 	if (OT_API_atexit_now) {
-		std::cerr << "\nSignal("<<signal<<"): for-atexit: we got ANOTER signal while processing a signal - aborting!" << std::endl;
 		abort();
 	}
 	OT_API_atexit_now=1;
-	std::cerr << "Signal("<<signal<<"): for-atexit cleanup handler." << std::endl;
 
 	OTAPI_Wrap::GoingDown(); // tell the wrapper that we are going down to make sure it will not race to create one while we are checking
 
 	OT_API * ot_api = OTAPI_Wrap::OTAPI(false); // just check if OTAPI was even created yet? (and write down the address)
 	if (ot_api) { // OTAPI was created
-		std::cerr << "Signal("<<signal<<"): for-atexit: will ask existing OT_API object to cleanup." << std::endl;
 		ot_api->CleanupForAtexit();
 	} 
 
-	std::cerr << "Signal("<<signal<<"): for-atexit cleanup handler- DONE" << std::endl;
 	OT_API_atexit_now=0;
 }
 
 void OT_API::CleanupForAtexit(int signal) {
-	std::cerr << "Signal("<<signal<<"): for-atexit cleanup method." << std::endl;
 	m_refPid.ClosePid();
-	std::cerr << "Signal("<<signal<<"): for-atexit cleanup method- DONE" << std::endl;
 }
 
 // ------------------------------------
@@ -972,7 +966,7 @@ OT_API::Pid::~Pid()
 bool OT_API_atexit_installed=0;  // (global - in this cpp only) is the atexit installed yet?
 
 void OT_API_signalHanlder(int signal) {
-	std::cerr << "Got signal="<<signal<<", exiting"<<std::endl;
+	std::cerr << "Got signal="<<signal<<" - will close and exit"<<std::endl;
 	OT_API_atexit(signal); // try to call it directly so it knows the signal that cuased it
 	exit(signal); // called also from here
 }
@@ -980,7 +974,7 @@ void OT_API_signalHanlder(int signal) {
 void OT_API::Pid::OpenPid(const OTString strPidFilePath)
 {
 	if (!OT_API_atexit_installed) {
-		std::cerr << "Installing signal handlers"<<std::endl; // TODO debug code
+		std::cerr << "Installing signal handlers"<<std::endl;
 		atexit(OT_API_atexit);
 		signal(SIGINT, OT_API_signalHanlder);  
 		signal(SIGTERM, OT_API_signalHanlder);

--- a/src/otapi/OpenTransactions.cpp
+++ b/src/otapi/OpenTransactions.cpp
@@ -789,6 +789,24 @@ void OT_API_atexit(int signal) { // for global signal handler - must be able to 
 	OT_API_atexit_now=0;
 }
 
+// signals (unix version mainly)
+bool OT_API_atexit_installed=0;  // (global - in this cpp only) is the atexit installed yet?
+bool OT_API_signalHandler_now=0; // now running a signal handler
+
+void OT_API_signalHanlder(int signal) {
+	if (OT_API_signalHandler_now) {
+		std::cerr << "Got signal="<<signal<<" while already in signal - abort"<<std::endl;
+		abort();
+	}
+	OT_API_signalHandler_now=1;
+	std::cerr << "Got signal="<<signal<<" - will close and exit"<<std::endl;
+	OT_API_atexit(signal); // try to call it directly so it knows the signal that cuased it
+	exit(signal); // called also from here
+	OT_API_signalHandler_now=0; // dead code
+}
+
+// =====================================================================
+
 void OT_API::CleanupForAtexit(int signal) {
 	if (m_refPid.IsPidOpen()) {
 		m_refPid.ClosePid();
@@ -963,15 +981,6 @@ OT_API::Pid::Pid()
 OT_API::Pid::~Pid()
 {
 	// nothing for now
-}
-
-
-bool OT_API_atexit_installed=0;  // (global - in this cpp only) is the atexit installed yet?
-
-void OT_API_signalHanlder(int signal) {
-	std::cerr << "Got signal="<<signal<<" - will close and exit"<<std::endl;
-	OT_API_atexit(signal); // try to call it directly so it knows the signal that cuased it
-	exit(signal); // called also from here
 }
 
 

--- a/src/tests/locks/main.cpp
+++ b/src/tests/locks/main.cpp
@@ -1,0 +1,61 @@
+#include <cstdlib>
+#include <csignal>
+#include <iostream>
+
+/**
+Test with:
+g++ main.cpp  && ./a.out
+
+and do CTRL-C and from other term kill  `pidof a.out`  or various combinations
+*/
+
+using std::cout;
+using std::cin;
+using std::endl;
+
+#define DBG(X) { std::cout << __LINE__ << ": " << X << endl; }
+
+extern int signalHandler_ctrlC_is_running_level; // 0=not 1=yes
+
+void signalHandler_ctrlC( int signum ) {
+	DBG("\nGot signal SIG" << signum );
+	if (signalHandler_ctrlC_is_running_level) {
+		DBG("We are already handling a shutdown and now another signal received - aborting now then.");
+		abort();
+	}
+	signalHandler_ctrlC_is_running_level = 1;
+
+	DBG("Will exit nicelly");
+	exit(signum);
+}
+
+void cleanup_pid_files() {
+	DBG("*** Cleaning up the PID locks ***");
+	cout << "Simulating problem here (press ENTER to continue or CTRL-C to break a program that hanged on cleanup)... " << endl;
+ 	std::string s; getline(cin,s);
+	DBG("PID locks are removed - bye");
+}
+
+void my_exit() {
+	DBG("my_exit");		
+	cleanup_pid_files();
+}
+
+
+int signalHandler_ctrlC_is_running_level=0;
+
+int main() {
+	DBG("started");
+	signal(SIGINT, signalHandler_ctrlC);  
+	signal(SIGTERM, signalHandler_ctrlC);  
+	signal(SIGHUP, signalHandler_ctrlC);  
+	signal(SIGSTOP, signalHandler_ctrlC);  
+
+	atexit( my_exit );
+
+	cout<<"Waiting (press ENTER to exit normally or CTRL-C to simulate canceling the program)... "; std::string s; getline(cin,s);
+
+	DBG("normal end of main()");
+	return 1;
+}
+


### PR DESCRIPTION
This makes ctrl-c and other program-canceled situations handled more  gracefully on Linux (and Windows - da2ce7).

Still not perfect (need to make signal handler low-level signal compatible_ but it clears the locks and program can be rund again easily.
