### PR TITLE
Amended opentxs.pc.in.

### DIFF
--- a/src/opentxs.pc.in
+++ b/src/opentxs.pc.in
@@ -13,6 +13,6 @@ cash, Ricardian contracts, smart contracts (with scriptable clauses), and more.
 URL: https://github.com/FellowTraveler/Open-Transactions
 Version: @VERSION@
 Requires: protobuf >= 2.4.1 chaiscript >= 3.1.0 openssl >= 1.0.0 libzmq >= 2.1.4
-Libs: -L${libdir} -lotapi-java -lotapi -lot
+Libs: -L${libdir} -lotapi -lot
 Libs.private: -lbigint -lirrxml -llucre -lotprotob -lotext
-Cflags: -I${includedir}/@PACKAGE@ -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wstack-protector
+Cflags: -I${includedir}/@PACKAGE@


### PR DESCRIPTION
Changed opentxs.pc pkg-config flags. No more reference to -lotapi-java and removed hardening flags (they are now up to external builders to provide).
