### PR TITLE
fix not-in-source builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ opentxs_include_dir     =   $(top_srcdir)/include
 opentxs_source_dir      =   $(top_srcdir)/src
 
 common_includes         =   $(AM_CXXFLAGS) \
+			    -I$(top_builddir)/include/otlib \
                             -I$(opentxs_include_dir)  \
                             -I$(opentxs_include_dir)/otlib
 

--- a/src/otapi/Makefile.am
+++ b/src/otapi/Makefile.am
@@ -14,7 +14,8 @@ opentxs_swig_dir	=	$(top_srcdir)/swig
 otlib_build_dir		=	$(top_builddir)/src/otlib
 
 common_includes		=	$(AM_CXXFLAGS)          \
-                -I$(opentxs_include_dir)		\
+				-I$(top_builddir)/include/otlib	\
+				-I$(opentxs_include_dir)		\
 				-I$(opentxs_include_dir)/otlib	\
 				-I$(opentxs_include_dir)/otapi
 

--- a/src/otlib/Makefile.am
+++ b/src/otlib/Makefile.am
@@ -8,6 +8,7 @@ opentxs_source_dir =		$(top_srcdir)/src
 ## COMMON FLAGS ###
 
 common_includes		=	$(AM_CXXFLAGS)			\
+                -I$(top_builddir)/include/otlib \
                 -I$(opentxs_include_dir)		\
 				-I$(opentxs_include_dir)/otlib	\
 				-I$(opentxs_include_dir)/containers	\
@@ -124,7 +125,7 @@ otlib_headers		=	$(otlib_headers_dir)/constants.h		\
 				$(otlib_headers_dir)/Timer.h			\
 				$(otlib_headers_ext)
 
-otlib_headers_ext	=	$(otlib_headers_dir)/ot_config.h    \
+otlib_headers_ext	=	$(top_builddir)/include/otlib/ot_config.h    \
                 $(otlib_headers_dir)/ExportWrapper.h		\
 				$(otlib_headers_dir)/stacktrace.h		\
 				$(otlib_headers_dir)/stdafx.h		\


### PR DESCRIPTION
this fix makes it possible to compile OT out-of-source folder, in particular with then new ot_config.h
