### PR TITLE
C++ flags turned on.

### DIFF
--- a/src/otlib/otext/Makefile.am
+++ b/src/otlib/otext/Makefile.am
@@ -15,7 +15,7 @@ otext_headers		=	$(otext_headers_dir)/anyoption.h	\
 				$(otext_headers_dir)/Timer.h
 
 libotext_la_SOURCES	=	$(otext_sources) $(otext_headers) $(simpleini_headers)
-libotext_la_CPPFLAGS	= $(AM_CPPFLAGS) -I$(otext_headers_dir)
+libotext_la_CXXFLAGS	= $(AM_CXXFLAGS) -I$(otext_headers_dir)
 libotext_la_LDFLAGS	=	-static --no-undefined
 
 


### PR DESCRIPTION
Better cflags for otext sublib now easyzlib.c is gone.
